### PR TITLE
Improve services megamenu accessibility

### DIFF
--- a/src/components/home/NavBar.jsx
+++ b/src/components/home/NavBar.jsx
@@ -1,9 +1,37 @@
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const NavBar = () => {
   const [servicesOpen, setServicesOpen] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const dropdownRef = useRef(null);
+
+  // Close the mega menu when clicking outside of it
+  useEffect(() => {
+    if (!servicesOpen) return;
+
+    const handleClickAway = (event) => {
+      if (!dropdownRef.current || dropdownRef.current.contains(event.target)) {
+        return;
+      }
+      setServicesOpen(false);
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        setServicesOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickAway);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickAway);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [servicesOpen]);
+
+  const closeServices = () => setServicesOpen(false);
 
   return (
     <div className="nav is-accent-primary">
@@ -32,139 +60,180 @@ const NavBar = () => {
               {/* SERVICES DROPDOWN */}
               <li className="nav_menu-list-item">
                 <div
+                  ref={dropdownRef}
                   className={`nav_dropdown-menu w-dropdown ${servicesOpen ? 'w--open' : ''}`}
                   onMouseEnter={() => setServicesOpen(true)}
                   onMouseLeave={() => setServicesOpen(false)}
+                  onFocus={() => setServicesOpen(true)}
+                  onBlur={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget)) {
+                      setServicesOpen(false);
+                    }
+                  }}
                 >
-                  <div
-                    className="nav_link on-accent-primary w-dropdown-toggle"
-                    onClick={() => setServicesOpen(!servicesOpen)}
-                    style={{ cursor: 'pointer' }}
+                  <button
+                    type="button"
+                    className={`nav_link on-accent-primary w-dropdown-toggle ${servicesOpen ? 'w--open' : ''}`}
+                    onClick={() => setServicesOpen((prev) => !prev)}
+                    aria-expanded={servicesOpen}
+                    aria-haspopup="true"
+                    style={{ cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
                   >
                     <div>Services</div>
                     <div className="nav-caret w-icon-dropdown-toggle"></div>
-                  </div>
+                  </button>
 
-                  {servicesOpen && (
-                    <nav className="mega-nav_dropdown-list w-dropdown-list">
-                      <div className="mega-nav_dropdown-list-wrapper">
-                        <ul className="grid_3-col tablet-1-col gap-medium margin-bottom_none w-list-unstyled">
-                          <li className="w-node">
-                            <div className="w-layout-grid grid_3-col tablet-1-col gap-small">
-                              {/* Column 1 */}
-                              <div>
-                                <div className="eyebrow">Dog walking</div>
-                                <ul className="mega-nav_list w-list-unstyled">
-                                  <li>
-                                    <Link to="/services/daily-strolls" className="mega-nav_link-item w-inline-block">
-                                      <div className="icon is-medium on-accent-primary">
-                                        {/* SVG omitted for brevity */}
-                                      </div>
-                                      <div>
-                                        <strong>Daily strolls</strong>
-                                        <div className="paragraph_small text-color_secondary">
-                                          Tailored walks for your furry friend.
-                                        </div>
-                                      </div>
-                                    </Link>
-                                  </li>
-                                  <li>
-                                    <Link to="/services/group-adventures" className="mega-nav_link-item w-inline-block">
-                                      <div className="icon is-medium on-accent-primary">
-                                        {/* SVG omitted for brevity */}
-                                      </div>
-                                      <div>
-                                        <strong>Group adventures</strong>
-                                        <div className="paragraph_small text-color_secondary">
-                                          Join friendly packs for social fun.
-                                        </div>
-                                      </div>
-                                    </Link>
-                                  </li>
-                                </ul>
-                              </div>
-                              {/* Column 2 */}
-                              <div>
-                                <div className="eyebrow">Boarding</div>
-                                <ul className="mega-nav_list w-list-unstyled">
-                                  <li>
-                                    <Link to="#" className="mega-nav_link-item w-inline-block">
-                                      <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
-                                      <div>
-                                        <strong>Overnight stays</strong>
-                                        <div className="paragraph_small text-color_secondary">
-                                          Safe and cozy nights.
-                                        </div>
-                                      </div>
-                                    </Link>
-                                  </li>
-                                  <li>
-                                    <Link to="#" className="mega-nav_link-item w-inline-block">
-                                      <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
-                                      <div>
-                                        <strong>Daytime care</strong>
-                                        <div className="paragraph_small text-color_secondary">
-                                          Engaging and secure day care.
-                                        </div>
-                                      </div>
-                                    </Link>
-                                  </li>
-                                </ul>
-                              </div>
-                              {/* Column 3 */}
-                              <div>
-                                <div className="eyebrow">Other services</div>
-                                <ul className="mega-nav_list w-list-unstyled">
-                                  <li>
-                                    <Link to="#" className="mega-nav_link-item w-inline-block">
-                                      <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
-                                      <div>
-                                        <strong>Pet transport</strong>
-                                        <div className="paragraph_small text-color_secondary">
-                                          Convenient travel for your pet.
-                                        </div>
-                                      </div>
-                                    </Link>
-                                  </li>
-                                  <li>
-                                    <Link to="#" className="mega-nav_link-item w-inline-block">
-                                      <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
-                                      <div>
-                                        <strong>Training help</strong>
-                                        <div className="paragraph_small text-color_secondary">
-                                          Guidance for training essentials.
-                                        </div>
-                                      </div>
-                                    </Link>
-                                  </li>
-                                </ul>
-                              </div>
-                            </div>
-                          </li>
-
-                          {/* Adventure card on the right */}
-                          <li className="flex_horizontal">
-                            <Link to="#" className="card-link is-inverse flex-child_expand w-inline-block">
-                              <div className="card_body">
-                                <div className="heading_h3">Plan your dog's next adventure</div>
-                                <p className="paragraph_small text-color_inverse-secondary">
-                                  Book a walk, boarding, or custom care today.
-                                </p>
-                                <div className="margin_top-auto">
-                                  <div className="button-group">
-                                    <div className="text-button is-secondary on-accent-primary">
-                                      <div>Contact us</div>
-                                      <div className="button_icon">{/* Arrow svg */}</div>
+                  <nav
+                    className={`mega-nav_dropdown-list w-dropdown-list ${servicesOpen ? 'w--open' : ''}`}
+                    aria-hidden={!servicesOpen}
+                  >
+                    <div
+                      className={`mega-nav_dropdown-list-wrapper ${servicesOpen ? 'w--open' : ''}`}
+                    >
+                      <ul className="grid_3-col tablet-1-col gap-medium margin-bottom_none w-list-unstyled">
+                        <li className="w-node">
+                          <div className="w-layout-grid grid_3-col tablet-1-col gap-small">
+                            {/* Column 1 */}
+                            <div>
+                              <div className="eyebrow">Dog walking</div>
+                              <ul className="mega-nav_list w-list-unstyled">
+                                <li>
+                                  <Link
+                                    to="/services/daily-strolls"
+                                    className="mega-nav_link-item w-inline-block"
+                                    onClick={closeServices}
+                                  >
+                                    <div className="icon is-medium on-accent-primary">
+                                      {/* SVG omitted for brevity */}
                                     </div>
+                                    <div>
+                                      <strong>Daily strolls</strong>
+                                      <div className="paragraph_small text-color_secondary">
+                                        Tailored walks for your furry friend.
+                                      </div>
+                                    </div>
+                                  </Link>
+                                </li>
+                                <li>
+                                  <Link
+                                    to="/services/group-adventures"
+                                    className="mega-nav_link-item w-inline-block"
+                                    onClick={closeServices}
+                                  >
+                                    <div className="icon is-medium on-accent-primary">
+                                      {/* SVG omitted for brevity */}
+                                    </div>
+                                    <div>
+                                      <strong>Group adventures</strong>
+                                      <div className="paragraph_small text-color_secondary">
+                                        Join friendly packs for social fun.
+                                      </div>
+                                    </div>
+                                  </Link>
+                                </li>
+                              </ul>
+                            </div>
+                            {/* Column 2 */}
+                            <div>
+                              <div className="eyebrow">Boarding</div>
+                              <ul className="mega-nav_list w-list-unstyled">
+                                <li>
+                                  <Link
+                                    to="/services/overnight-stays"
+                                    className="mega-nav_link-item w-inline-block"
+                                    onClick={closeServices}
+                                  >
+                                    <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
+                                    <div>
+                                      <strong>Overnight stays</strong>
+                                      <div className="paragraph_small text-color_secondary">
+                                        Safe and cozy nights.
+                                      </div>
+                                    </div>
+                                  </Link>
+                                </li>
+                                <li>
+                                  <Link
+                                    to="/services/daytime-care"
+                                    className="mega-nav_link-item w-inline-block"
+                                    onClick={closeServices}
+                                  >
+                                    <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
+                                    <div>
+                                      <strong>Daytime care</strong>
+                                      <div className="paragraph_small text-color_secondary">
+                                        Engaging and secure day care.
+                                      </div>
+                                    </div>
+                                  </Link>
+                                </li>
+                              </ul>
+                            </div>
+                            {/* Column 3 */}
+                            <div>
+                              <div className="eyebrow">Other services</div>
+                              <ul className="mega-nav_list w-list-unstyled">
+                                <li>
+                                  <Link
+                                    to="/services/pet-transport"
+                                    className="mega-nav_link-item w-inline-block"
+                                    onClick={closeServices}
+                                  >
+                                    <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
+                                    <div>
+                                      <strong>Pet transport</strong>
+                                      <div className="paragraph_small text-color_secondary">
+                                        Convenient travel for your pet.
+                                      </div>
+                                    </div>
+                                  </Link>
+                                </li>
+                                <li>
+                                  <Link
+                                    to="/services/training-help"
+                                    className="mega-nav_link-item w-inline-block"
+                                    onClick={closeServices}
+                                  >
+                                    <div className="icon is-medium on-accent-primary">{/* SVG */}</div>
+                                    <div>
+                                      <strong>Training help</strong>
+                                      <div className="paragraph_small text-color_secondary">
+                                        Guidance for training essentials.
+                                      </div>
+                                    </div>
+                                  </Link>
+                                </li>
+                              </ul>
+                            </div>
+                          </div>
+                        </li>
+
+                        {/* Adventure card on the right */}
+                        <li className="flex_horizontal">
+                          <Link
+                            to="/contact"
+                            className="card-link is-inverse flex-child_expand w-inline-block"
+                            onClick={closeServices}
+                          >
+                            <div className="card_body">
+                              <div className="heading_h3">Plan your dog's next adventure</div>
+                              <p className="paragraph_small text-color_inverse-secondary">
+                                Book a walk, boarding, or custom care today.
+                              </p>
+                              <div className="margin_top-auto">
+                                <div className="button-group">
+                                  <div className="text-button is-secondary on-accent-primary">
+                                    <div>Contact us</div>
+                                    <div className="button_icon">{/* Arrow svg */}</div>
                                   </div>
                                 </div>
                               </div>
-                            </Link>
-                          </li>
-                        </ul>
-                      </div>
-                    </nav>
-                  )}
+                            </div>
+                          </Link>
+                        </li>
+                      </ul>
+                    </div>
+                  </nav>
                 </div>
               </li>
 
@@ -191,9 +260,9 @@ const NavBar = () => {
         {/* Right side reserve button */}
         <div className="nav_right">
           <div className="button-group margin-top_none">
-            <a href="#" className="button on-accent-primary w-inline-block">
+            <Link to="/contact" className="button on-accent-primary w-inline-block">
               <div className="button_label">Reserve</div>
-            </a>
+            </Link>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- ensure the Services mega menu stays open by toggling the Webflow classes, supporting hover, click, and keyboard interactions
- replace placeholder anchors in the Services menu and Reserve CTA with react-router-dom links so navigation stays in-app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd546a7e04832cbd83e2b7647ce6b5