### PR TITLE
Fix GitHub Pages base path configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/images/favicon.ico" />
+    <link rel="icon" type="image/png" href="%BASE_URL%images/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Jeroen &amp; Paws</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,8 @@ function WebflowReInit() {
 }
 
 function AppContent() {
+  const basePath = import.meta.env.BASE_URL;
+
   useEffect(() => {
     const root = document.documentElement;
     root.classList.add('w-mod-js');
@@ -58,7 +60,7 @@ function AppContent() {
 
     const handleJQueryLoad = () => {
       const webflowScript = document.createElement('script');
-      webflowScript.src = '/js/webflow.js';
+      webflowScript.src = `${basePath}js/webflow.js`;
       webflowScript.async = false;
       document.body.appendChild(webflowScript);
     };
@@ -70,7 +72,7 @@ function AppContent() {
       jqueryScript.removeEventListener('load', handleJQueryLoad);
       if (jqueryScript.parentNode) jqueryScript.parentNode.removeChild(jqueryScript);
     };
-  }, []);
+  }, [basePath]);
 
   return (
     <>
@@ -87,8 +89,10 @@ function AppContent() {
 }
 
 export default function App() {
+  const basePath = import.meta.env.BASE_URL;
+
   return (
-    <Router>
+    <Router basename={basePath}>
       <AppContent />
     </Router>
   );

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/JeroenandPaws/',
   plugins: [react()],
   server: {
     open: true


### PR DESCRIPTION
## Summary
- configure Vite to build assets with the repository subdirectory as the base path
- ensure the router and dynamically loaded scripts respect the GitHub Pages base URL
- make the favicon path resilient to different deployment bases

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd63648648832c800f590b19003740