### PR TITLE
Add CSS assets and remove invalid background image references

### DIFF
--- a/src/assets/css/jeroen-paws.webflow.css
+++ b/src/assets/css/jeroen-paws.webflow.css
@@ -1,0 +1,7101 @@
+:root {
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-width: 1280px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-lg-width: 1440px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-sm-width: 1000px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-inverse);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-tablet\<deleted\|variable-ee5fee03-9f5f-fa94-863a-74076777e574\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-l\<deleted\|variable-24c154e3-e2bd-2abe-9e97-cc8c13b92cad\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-p\<deleted\|variable-db6b96b3-2108-c94d-520b-97f547fae1ec\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary: #fff;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-inverse);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary: #fff;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-tertiary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary: #fff;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x: 1.25rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-size: .9rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-line-height: 1.3em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight: 400;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-letter-spacing: .01em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-margin-bottom: .3em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font: "DM Sans", sans-serif;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-size: 5.61rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-line-height: 1.04em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-weight: 500;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-letter-spacing: -.01em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-margin-bottom: .3em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-size: 4.21rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-line-height: 1.04em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-weight: 500;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-letter-spacing: -.01em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-margin-bottom: .35em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-size: 2.37rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-line-height: 1.04em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-weight: 500;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-letter-spacing: -.01em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-margin-bottom: .5em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-size: 1.78rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-line-height: 1.04em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-weight: 500;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-letter-spacing: -.01em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-margin-bottom: .35em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-size: 1.33rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-line-height: 1.3em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-weight: 500;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-letter-spacing: -.01em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-margin-bottom: .5em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-size: 1rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-line-height: 1.3em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-weight: 500;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-letter-spacing: 0em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-margin-bottom: .5em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-size: .75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-line-height: 1.3em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-weight: 500;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-letter-spacing: .1em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom: .7em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font: Manrope, sans-serif;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size: 1.13rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-line-height: 1.6em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-letter-spacing: 0em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-size: 1.5rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-line-height: 1.6em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-letter-spacing: 0em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-size: .88rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-line-height: 1.6em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-letter-spacing: 0em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius: 1rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical: 1em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal: 1.5em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-border: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius: .75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary: #7c45f3;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---button--button-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size: 1rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-border-hover: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover: #a47ef7;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-border: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20: #7c45f333;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-border-hover: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a10: #7c45f31a;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20: #fff3;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10: #ffffff1a;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-inverse-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-inverse-hover);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x: .75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary: #0c081f;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a90: #ffffffe6;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a60: #fff9;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a50: #ffffff80;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius: .75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-text-placeholder: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10: #0c081f1a;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-text-placeholder: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a50);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-bg: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-bg-hover: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30: #ffffff4d;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x: 1rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x: 2rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x: .5rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x: 1.5rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius: .25rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-control: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x: 4rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round: 100rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x: 5rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-size: 2rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-line-height: 1.6em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-letter-spacing: 0em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x: 3rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-border: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-secondary-border: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-secondary-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-secondary-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-primary-border: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-primary-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-primary-text: white;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-border: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20: #0c081f33;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-card-spacing: 2rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-secondary-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-tertiary-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x: 8rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-tablet\<deleted\|variable-6cc22bfd-2df9-6b9d-c99e-fb5b9e0b9202\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-l\<deleted\|variable-2a022f41-6678-bea5-0011-a28ef08eeb2c\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-p\<deleted\|variable-8ffe64f7-5df6-3612-eccc-e3b77e1606d7\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-secondary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a60);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a60: #0c081f99;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-inverse: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-inverse);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary: #9065ef;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x: .25rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-accent: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius: .75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---tag--tag-size: .75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a80: #fffc;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-overlay: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-bg: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-bg-hover: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-inverse: #fff;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary-hover: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary-hover);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-secondary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius: .5rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--lg-radius: .75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--xl-radius: 1rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x: 6rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-size: 1rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a10);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---nav-link--nav-link-inverse: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-secondary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a60);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a90: #7c45f3e6;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a80: #7c45f3cc;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a70: #7c45f3b3;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a60: #7c45f399;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a50: #7c45f380;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a40: #7c45f366;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a30: #7c45f34d;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a90: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a80: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a70: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a60: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a50: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a40: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a30: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a20: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a10: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-tertiary: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-tertiary-hover: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a90: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a70: #ffffffb3;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a40: #fff6;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a90: #0c081fe6;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a80: #0c081fcc;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a70: #0c081fb3;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a50: #0c081f80;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a40: #0c081f66;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a30: #0c081f4d;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a10: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a20: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a30: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a40: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a50: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a60: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a70: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a80: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-secondary: #121026;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-card-change-width: 50%;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-inverse: #7c45f3;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-bg: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---nav-link--nav-link-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-overlay: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-inverse);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary-hover: #9065ef99;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-inverse-hover: #7c45f399;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-inverse-primary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-inverse-secondary: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-75x: 1.75rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x: 7rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font: Manrope, sans-serif;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight-bold: 600;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-letter-spacing: 0em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-line-height: 1.6rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-letter-spacing: 0em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-line-height: 1.6em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---blockquote--blockquote-bg: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---blockquote--blockquote-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---blockquote--blockquote-border: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-radius: 0px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-border-width: 3px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-size: 1rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-letter-spacing: .01em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-line-height: 1.3em;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-text: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-control-border: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-secondary-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-primary-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-secondary-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-secondary-text: white;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-secondary-border: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-tertiary-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-tertiary-text: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-tertiary-border: transparent;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-bg-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---nav--nav-height: 4rem;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-secondary-hover: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a60);
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-hero-intro-slide-up-100vh: 0px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-hero-intro-clipping-mask-1: 0px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-hero-intro-clipping-mask-2: 0px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-hero-intro-clipping-mask-3: 0px;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-follow-cursor: 0%;
+  --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-nav-width: 0px;
+}
+
+.w-layout-grid {
+  grid-row-gap: 16px;
+  grid-column-gap: 16px;
+  grid-template-rows: auto auto;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.w-checkbox {
+  margin-bottom: 5px;
+  padding-left: 20px;
+  display: block;
+}
+
+.w-checkbox:before {
+  content: " ";
+  grid-area: 1 / 1 / 2 / 2;
+  display: table;
+}
+
+.w-checkbox:after {
+  content: " ";
+  clear: both;
+  grid-area: 1 / 1 / 2 / 2;
+  display: table;
+}
+
+.w-checkbox-input {
+  float: left;
+  margin: 4px 0 0 -20px;
+  line-height: normal;
+}
+
+.w-checkbox-input--inputType-custom {
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.w-checkbox-input--inputType-custom.w--redirected-checked {
+  background-color: #3898ec;
+  background-image: url('https://d3e54v103j8qbb.cloudfront.net/static/custom-checkbox-checkmark.589d534424.svg');
+  background-position: 50%;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border-color: #3898ec;
+}
+
+.w-checkbox-input--inputType-custom.w--redirected-focus {
+  box-shadow: 0 0 3px 1px #3898ec;
+}
+
+.w-form-formradioinput--inputType-custom {
+  border: 1px solid #ccc;
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+}
+
+.w-form-formradioinput--inputType-custom.w--redirected-focus {
+  box-shadow: 0 0 3px 1px #3898ec;
+}
+
+.w-form-formradioinput--inputType-custom.w--redirected-checked {
+  border-width: 4px;
+  border-color: #3898ec;
+}
+
+.w-layout-vflex {
+  flex-direction: column;
+  align-items: flex-start;
+  display: flex;
+}
+
+.w-layout-hflex {
+  flex-direction: row;
+  align-items: flex-start;
+  display: flex;
+}
+
+.container {
+  max-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-width);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-padding-horizontal);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-padding-horizontal);
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.container.is-max {
+  width: 100%;
+  max-width: none;
+}
+
+.container.is-large {
+  max-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-lg-width);
+  width: 100%;
+}
+
+.container.is-small {
+  max-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-sm-width);
+}
+
+.section {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  overflow: clip;
+}
+
+.section.is-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+}
+
+.section.is-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+}
+
+.section.is-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.section.is-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+}
+
+.section.is-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+}
+
+.eyebrow {
+  margin-top: 0;
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-letter-spacing);
+  text-transform: uppercase;
+  color: color-mix(in srgb, currentColor 60%, transparent);
+  display: inline-block;
+}
+
+.eyebrow.margin-bottom_none {
+  margin-bottom: 0;
+}
+
+.grid_2-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.grid_2-col.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.grid_2-col.gap-medium {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.grid_2-col.is-x-center {
+  justify-items: center;
+}
+
+.grid_2-col.gap-xsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  align-self: stretch;
+}
+
+.grid_2-col.gap-xxlarge {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap);
+}
+
+.grid_2-col.gap-large {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+}
+
+.heading_huge {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-letter-spacing);
+  text-wrap: balance;
+}
+
+.heading_h1 {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-letter-spacing);
+  text-wrap: balance;
+}
+
+.heading_h2 {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-letter-spacing);
+  text-wrap: balance;
+}
+
+.heading_h3 {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-letter-spacing);
+}
+
+.heading_h4 {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-letter-spacing);
+}
+
+.heading_h5 {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-letter-spacing);
+}
+
+.heading_h5.margin-bottom_none {
+  margin-bottom: 0;
+}
+
+.heading_h6 {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-line-height);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-weight);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-letter-spacing);
+}
+
+.paragraph_large {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-line-height);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-letter-spacing);
+}
+
+.paragraph_xlarge {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-line-height);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-letter-spacing);
+}
+
+.paragraph_small {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-line-height);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-letter-spacing);
+}
+
+.sg_preview-bordered {
+  border: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  pointer-events: auto;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 10rem;
+  padding: 1.5rem;
+}
+
+.background_primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+}
+
+.text-color_primary {
+  color: inherit;
+}
+
+.button {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal);
+  grid-column-gap: .5em;
+  grid-row-gap: .5em;
+  border: 0px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-border);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---button--button-font);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size);
+  text-align: center;
+  cursor: pointer;
+  background-image: none;
+  justify-content: center;
+  align-items: center;
+  font-weight: 400;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: border-color .2s, color .2s, background-color .2s cubic-bezier(.165, .84, .44, 1), box-shadow .2s;
+  display: inline-flex;
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-border-hover);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-text);
+  box-shadow: 0 1px 1px #0003, 0 8px 8px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button:focus {
+  outline-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+}
+
+.button.is-secondary {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20);
+  box-shadow: none;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.button.is-secondary:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-border-hover);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a10);
+  box-shadow: none;
+}
+
+.button.is-secondary:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20);
+  box-shadow: none;
+}
+
+.button.is-secondary.on-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: none;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.button.is-secondary.on-accent-primary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10);
+  box-shadow: none;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-inverse-hover);
+}
+
+.button.is-secondary.on-accent-primary:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: none;
+}
+
+.button.is-secondary.on-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: none;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.button.is-secondary.on-accent-secondary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10);
+  box-shadow: none;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-inverse-hover);
+}
+
+.button.is-secondary.on-accent-secondary:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: none;
+}
+
+.button.is-secondary.on-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: none;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.button.is-secondary.on-accent-tertiary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10);
+  box-shadow: none;
+}
+
+.button.is-secondary.on-accent-tertiary:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: none;
+}
+
+.button.is-secondary.on-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20);
+  box-shadow: none;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  background-image: none;
+}
+
+.button.is-secondary.on-inverse:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a10);
+  box-shadow: none;
+}
+
+.button.is-secondary.on-inverse:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20);
+  box-shadow: none;
+}
+
+.button.is-small {
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+}
+
+.button.is-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  border-color: #0000;
+}
+
+.button.is-inverse:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover);
+  border-color: #0000;
+}
+
+.button.on-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-image: linear-gradient(var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a90), var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a60));
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-primary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a50);
+  border-color: #0000;
+  box-shadow: 0 1px 1px #0003, 0 8px 8px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-primary:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+  background-image: none;
+  border-color: #0000;
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-inverse:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover);
+  border-color: #0000;
+  box-shadow: 0 1px 1px #0003, 0 8px 8px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-inverse:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-image: linear-gradient(var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a90), var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a60));
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-secondary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a50);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  box-shadow: 0 1px 1px #0003, 0 8px 8px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-secondary:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-image: linear-gradient(var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a90), var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a60));
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-tertiary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a50);
+  box-shadow: 0 1px 1px #0003, 0 8px 8px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.button.on-accent-tertiary:active {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 1px 1px #0003, 0 4px 4px #0003, inset 0 3px 2px -2px #ffffff80;
+}
+
+.display_inline-block {
+  display: inline-block;
+}
+
+.input {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  position: relative;
+}
+
+.input_label {
+  z-index: 1;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  margin-bottom: .5em;
+  font-size: .75rem;
+  font-weight: 400;
+  line-height: 1.4;
+  position: relative;
+}
+
+.input_field {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-vertical) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-horizontal);
+  border: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-color: #0000;
+  background-image: linear-gradient(#0000001a, #0000);
+  height: auto;
+  margin-bottom: 0;
+  font-size: 1rem;
+  line-height: 1.3;
+  transition: background-color .2s cubic-bezier(.165, .84, .44, 1), border-color .2s cubic-bezier(.165, .84, .44, 1);
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border-hover);
+  background-color: #0000;
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field:focus {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  outline-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+}
+
+.input_field::placeholder {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-text-placeholder);
+}
+
+.input_field.is-select {
+  border-top-width: 0;
+  border-top-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  border-right-width: 0;
+  border-right-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  border-bottom-width: 0;
+  border-bottom-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  border-left-width: 0;
+  border-left-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary), 0 4px 4px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+  font-size: 1rem;
+  transition-property: border-color, color, background-color, box-shadow;
+  transition-duration: .2s;
+  transition-timing-function: ease, ease, cubic-bezier(.165, .84, .44, 1), ease;
+}
+
+.input_field.is-select:hover {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary), 0 6px 12px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select:focus-visible, .input_field.is-select[data-wf-focus-visible] {
+  outline-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+}
+
+.input_field.is-select.on-inverse {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10), 0 4px 4px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  background-color: #0000;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select.on-inverse:hover {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10), 0 6px 12px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  background-color: #0000;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select.on-accent-primary {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20), 0 4px 4px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  transition: border-color .2s ease, color undefined ease, background-color undefined cubic-bezier(.165, .84, .44, 1), box-shadow undefined ease;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select.on-accent-primary:hover {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20), 0 6px 12px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select.on-accent-secondary {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20), 0 4px 4px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  transition: border-color .2s ease, color undefined ease, background-color undefined cubic-bezier(.165, .84, .44, 1), box-shadow undefined ease;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select.on-accent-secondary:hover {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20), 0 6px 12px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select.on-accent-tertiary {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20), 0 4px 4px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  transition: border-color .2s ease, color undefined ease, background-color undefined cubic-bezier(.165, .84, .44, 1), box-shadow undefined ease;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.is-select.on-accent-tertiary:hover {
+  border-width: 0;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20), 0 6px 12px #00000040, 0 1px 1px #0003, 0 2px 1px #ffffff4d inset;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+
+.input_field.on-inverse {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  background-color: #0000;
+  background-image: linear-gradient(#0000001a, #0000);
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.on-inverse:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border-hover);
+  background-color: #0000;
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.on-inverse:focus {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border);
+  outline-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+}
+
+.input_field.on-inverse::placeholder {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-text-placeholder);
+}
+
+.input_field.is-text-area {
+  min-height: 7.5rem;
+}
+
+.input_field.is-inverse {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-text);
+  min-height: 7.5rem;
+}
+
+.input_field.is-inverse:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border-hover);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-bg-hover);
+}
+
+.input_field.is-inverse::placeholder {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-text-placeholder);
+}
+
+.input_field.on-accent-primary {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-color: #0000;
+  background-image: linear-gradient(#0000001a, #0000);
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.on-accent-primary:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+  background-color: #0000;
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.on-accent-secondary {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-color: #0000;
+  background-image: linear-gradient(#0000001a, #0000);
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.on-accent-secondary:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+  background-color: #0000;
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.on-accent-tertiary {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-color: #0000;
+  background-image: linear-gradient(#0000001a, #0000);
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.on-accent-tertiary:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+  background-color: #0000;
+  box-shadow: inset 0 4px 4px -2px #0000001a;
+}
+
+.input_field.input_text-area {
+  min-height: 7.5rem;
+}
+
+.margin-top_none {
+  margin-top: 0 !important;
+}
+
+.margin-bottom_none {
+  margin-bottom: 0 !important;
+}
+
+.padding-bottom_none {
+  padding-bottom: 0 !important;
+}
+
+.padding-top_none {
+  padding-top: 0 !important;
+}
+
+.padding-bottom_xsmall {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.padding-bottom_small {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.padding-top_xxsmall {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+}
+
+.padding-top_xsmall {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.padding-top_small {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.display_none {
+  display: none;
+}
+
+.display_block {
+  display: block;
+}
+
+.overflow_hidden {
+  overflow: hidden;
+}
+
+.overflow_visible {
+  overflow: visible !important;
+}
+
+.screen-reader {
+  white-space: nowrap;
+  border: 0 solid #0000;
+  width: 1px;
+  height: 1px;
+  margin-top: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.text-align_center {
+  text-align: center;
+}
+
+.text-align_right {
+  text-align: right;
+}
+
+.margin_top-auto {
+  margin-top: auto !important;
+}
+
+.position_relative {
+  position: relative;
+}
+
+.position_relative.z-index_1 {
+  z-index: 1;
+}
+
+.position_sticky {
+  position: sticky;
+  top: 0;
+}
+
+.position_sticky.is-top-section-padding {
+  top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical);
+}
+
+.sg_selector {
+  color: #006aff;
+  letter-spacing: 0;
+  text-transform: none;
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: color-mix(in srgb, currentColor 20%, transparent);
+  border-right-color: color-mix(in srgb, currentColor 20%, transparent);
+  border-bottom-color: color-mix(in srgb, currentColor 20%, transparent);
+  border-left-color: color-mix(in srgb, currentColor 20%, transparent);
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
+  border-radius: 4px;
+  align-self: flex-start;
+  margin-bottom: .2em;
+  margin-right: .2em;
+  padding-left: .4em;
+  padding-right: .4em;
+  font-size: .85rem;
+  font-weight: 400;
+  line-height: 1.7;
+  display: inline-block;
+  position: relative;
+}
+
+.checkbox_toggle {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  min-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  min-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  margin-top: 0;
+  margin-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: color-mix(in srgb, currentColor 50%, transparent);
+  border-right-color: color-mix(in srgb, currentColor 50%, transparent);
+  border-bottom-color: color-mix(in srgb, currentColor 50%, transparent);
+  border-left-color: color-mix(in srgb, currentColor 50%, transparent);
+  margin-left: -32px;
+  transition-property: border-color, background-color;
+  transition-duration: .2s, .2s;
+  transition-timing-function: cubic-bezier(.165, .84, .44, 1), cubic-bezier(.165, .84, .44, 1);
+}
+
+.checkbox_toggle:hover {
+  box-shadow: color-mix(in srgb, currentColor 30%, transparent) 0px 0px 0px 4px;
+}
+
+.checkbox_toggle:focus {
+  outline-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+}
+
+.checkbox_toggle.w--redirected-checked {
+  border-style: none;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-text);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-control);
+  background-image: none;
+  background-position: 50%;
+  background-repeat: no-repeat;
+  background-size: 12px 12px;
+}
+
+.checkbox_toggle.w--redirected-focus {
+  box-shadow: none;
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+  outline-color: color-mix(in srgb, currentColor 40%, transparent);
+}
+
+.checkbox_toggle.w--redirected-focus-visible {
+  border-top-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border-hover);
+  border-right-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border-hover);
+  border-bottom-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border-hover);
+  border-left-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border-hover);
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+  outline-color: color-mix(in srgb, currentColor 40%, transparent);
+}
+
+.checkbox_toggle.on-inverse {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-bg);
+}
+
+.checkbox_toggle.on-inverse:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border-hover);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-bg-hover);
+}
+
+.checkbox_toggle.on-inverse.w--redirected-checked {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-text);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-text);
+  background-image: none;
+}
+
+.avatar {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  object-fit: cover;
+  flex: none;
+  position: relative;
+  overflow: hidden;
+}
+
+.avatar.is-small {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.avatar.is-large {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+}
+
+.image_cover {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.image_cover.position_relative {
+  position: relative;
+}
+
+.z-index_1 {
+  z-index: 1;
+}
+
+.margin-right_none {
+  margin-right: 0;
+}
+
+.margin-left_none {
+  margin-left: 0;
+}
+
+.link-overlay {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0%;
+}
+
+.paragraph_xxlarge {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-line-height);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-letter-spacing);
+}
+
+.button-group {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+  display: flex;
+}
+
+.button-group.is-align-center {
+  justify-content: center;
+}
+
+.button-group.is-align-right {
+  justify-content: flex-end;
+}
+
+.button-group.is-vertical-stretch {
+  flex-flow: column;
+  align-items: stretch;
+}
+
+.margin-top_xxsmall {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+}
+
+.margin-top_xsmall {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.margin-top_small {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.margin-top_large {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+}
+
+.margin-top_medium {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+}
+
+.margin-bottom_xxsmall {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+}
+
+.margin-bottom_xsmall {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.margin-bottom_small {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.margin-bottom_medium {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+}
+
+.margin-bottom_large {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+}
+
+.padding-bottom_medium {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+}
+
+.padding-bottom_large {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+}
+
+.padding-top_medium {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+}
+
+.padding-top_large {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+}
+
+.image-ratio_3x2 {
+  aspect-ratio: 3 / 2;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  position: relative;
+  overflow: clip;
+}
+
+.rich-text p {
+  font-size: inherit;
+}
+
+.rich-text ol {
+  overflow: visible;
+}
+
+.rich-text li {
+  margin-bottom: .5em;
+  padding-left: 4px;
+}
+
+.rich-text blockquote {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.rich-text img {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+}
+
+.divider {
+  -webkit-text-stroke-width: 0px;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: color-mix(in srgb, currentColor 15%, transparent);
+  align-self: stretch;
+}
+
+.divider.is-secondary {
+  border-bottom-color: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.divider.is-accent {
+  border-bottom-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+}
+
+.card {
+  border: 0px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-border);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20) inset, 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+  flex-flow: row;
+  flex: 0 auto;
+  list-style-type: none;
+  overflow: hidden;
+}
+
+.card.is-secondary {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-secondary-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-secondary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-secondary-text);
+}
+
+.card.is-accent-primary {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-primary-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-primary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-primary-text);
+}
+
+.card.is-inverse {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-text);
+}
+
+.card.on-secondary {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20) inset, 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.card.on-inverse {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20) inset, 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  background-image: none;
+}
+
+.card.ix_card-slide-up-1, .card.ix_card-slide-up-2, .card.ix_card-slide-up-3 {
+  z-index: 1;
+  pointer-events: auto;
+  transition: opacity .3s cubic-bezier(.55, .055, .675, .19), transform .3s cubic-bezier(.55, .055, .675, .19);
+  position: relative;
+}
+
+.card.ix_card-slide-up-3:hover {
+  position: relative;
+}
+
+.card.ix_card-slide-up-4 {
+  z-index: 1;
+  pointer-events: auto;
+  transition: opacity .3s cubic-bezier(.55, .055, .675, .19), transform .3s cubic-bezier(.55, .055, .675, .19);
+  position: relative;
+}
+
+.card.ix_card-slide-up-4:hover {
+  z-index: 99;
+}
+
+.card.ix_card-deck-space {
+  z-index: 1;
+  margin-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-card-spacing);
+  flex: none;
+  align-self: stretch;
+  transition: margin-right .5s cubic-bezier(.68, -.55, .265, 1.55);
+}
+
+.card.on-accent-primary, .card.on-accent-secondary, .card.on-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20), 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.card.is-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-secondary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+}
+
+.card.is-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-accent-tertiary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+}
+
+.card.ix_sticky-height-expand-wrapper {
+  pointer-events: auto;
+  width: 100%;
+  height: 0;
+  min-height: 8rem;
+  max-height: 100%;
+  overflow: clip;
+}
+
+.margin-top_xxlarge {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x);
+}
+
+.margin-bottom_xxlarge {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x);
+}
+
+.card_body {
+  z-index: 1;
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding);
+  flex-flow: column;
+  flex: 1;
+  justify-content: flex-start;
+  align-items: stretch;
+  min-height: 100%;
+  display: flex;
+  position: relative;
+}
+
+.card_body.is-small {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.slider_mask {
+  min-width: auto;
+  height: auto;
+  overflow: visible;
+}
+
+.slider {
+  background-color: #0000;
+  height: auto;
+  overflow: hidden;
+}
+
+.slider.overflow_visible {
+  overflow: visible;
+}
+
+.slider_nav {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+  filter: contrast(50%) sepia() invert(50%);
+  mix-blend-mode: luminosity;
+  justify-content: center;
+  align-items: center;
+  margin-left: 0;
+  margin-right: 0;
+  display: flex;
+  position: relative;
+}
+
+.nav {
+  z-index: 99;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size);
+  background-color: #fff0;
+  justify-content: center;
+  align-items: flex-start;
+  width: 100%;
+  display: flex;
+  position: relative;
+}
+
+.nav.is-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.nav.is-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+}
+
+.nav.is-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+}
+
+.nav.is-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+}
+
+.nav.is-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+}
+
+.nav_mobile-menu-button {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  color: inherit;
+  flex-flow: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.nav_mobile-menu-button:hover {
+  color: inherit;
+}
+
+.nav_mobile-menu-button.w--open {
+  z-index: 2;
+  background-color: #0000;
+}
+
+.nav_mobile-menu-button.w--open:hover {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-inverse-hover);
+}
+
+.nav_mobile-menu-button.fixed-open-nav.w--open {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-secondary);
+  position: fixed;
+}
+
+.slider_arrow {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a60);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  justify-content: center;
+  align-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-left: 0;
+  margin-right: 0;
+  text-decoration: none;
+  transition: color .2s, background-color .2s;
+  display: flex;
+  left: auto;
+  right: auto;
+}
+
+.slider_arrow:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+}
+
+.slider_arrow.is-next.is-bottom-center {
+  text-align: left;
+  width: 2.5rem;
+  margin-left: .5rem;
+  inset: auto auto -4rem 50%;
+}
+
+.slider_arrow.is-previous.is-bottom-center {
+  margin-right: .5rem;
+  inset: auto 50% -4rem auto;
+}
+
+.slider_arrow.is-inverse {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-inverse);
+  background-color: color-mix(in srgb, currentColor 0%, transparent);
+}
+
+.slider_arrow.is-inverse:hover {
+  background-color: color-mix(in srgb, currentColor 20%, transparent);
+}
+
+.slider_arrow.is-next-bottom {
+  position: absolute;
+  inset: auto 0% 0% auto;
+}
+
+.slider_arrow.is-prev-bottom {
+  margin-right: 2.5rem;
+  position: absolute;
+  inset: auto 0% 0% auto;
+}
+
+.move-down_50percent {
+  transform: translate(0, 50%);
+}
+
+.move-up_15percent {
+  transform: translate(0, -15%);
+}
+
+.image-ratio_2x3 {
+  aspect-ratio: 2 / 3;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  position: relative;
+  overflow: clip;
+}
+
+.height_100percent {
+  height: 100%;
+}
+
+.flex_horizontal {
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  flex-flow: row;
+  display: flex;
+}
+
+.flex_horizontal.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.flex_horizontal.flex_vertical {
+  flex-direction: column;
+}
+
+.flex_horizontal.flex_vertical.is-space-between {
+  justify-content: space-between;
+}
+
+.flex_horizontal.gap-xsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+}
+
+.flex_horizontal.gap-xxsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+}
+
+.flex_horizontal.is-wrap {
+  flex-wrap: wrap;
+}
+
+.flex_horizontal.gap-large {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+}
+
+.flex_horizontal.gap-medium {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.flex_horizontal.is-x-center {
+  justify-content: center;
+}
+
+.flex_horizontal.is-shift-left {
+  transform: translate(-15%);
+}
+
+.flex_horizontal.is-align-center {
+  align-items: center;
+}
+
+.width_100percent {
+  width: 100%;
+}
+
+.icon_small {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary);
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: relative;
+}
+
+.icon_large {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary);
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.margin-right_xsmall {
+  margin-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+}
+
+.grid_masonry {
+  column-count: 2;
+  column-gap: 2rem;
+}
+
+.margin-right_medium {
+  margin-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.accordion {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  background-color: color-mix(in srgb, currentColor 5%, transparent);
+  width: 100%;
+}
+
+.accordion:hover {
+  background-color: color-mix(in srgb, currentColor 8%, transparent);
+}
+
+.accordion.is-transparent {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: color-mix(in srgb, currentColor 40%, transparent);
+  background-color: #0000;
+  border-radius: 0;
+  margin-bottom: 0;
+}
+
+.accordion_toggle {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  grid-column-gap: 1rem;
+  grid-row-gap: 1rem;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size);
+  line-height: 1.2;
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-weight);
+  background-color: #0000;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  height: 3.25rem;
+  transition: border-color .2s, background-color .2s;
+  display: flex;
+}
+
+.accordion_toggle.w--open {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.accordion_content {
+  background-color: #0000;
+  padding: 0;
+  position: static;
+  overflow: hidden;
+}
+
+.accordion_content.w--open {
+  position: relative;
+}
+
+.rotate_4-5deg {
+  transform: rotate(4.5deg);
+}
+
+.rotate_-4-5deg {
+  transform: rotate(-4.5deg);
+}
+
+.margin-right_small {
+  margin-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.padding_large {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+}
+
+.accordion_icon {
+  order: 1;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-right: 0;
+  position: relative;
+}
+
+.accordion_icon.is-inverse {
+  transform: rotate(180deg);
+}
+
+.position_static {
+  position: static;
+}
+
+.position_absolute {
+  position: absolute;
+}
+
+.position_absolute.absolute-left-100 {
+  inset: 0% auto 0% 100%;
+}
+
+.icon_xlarge {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary);
+  flex: none;
+}
+
+.image-ratio_4x3 {
+  aspect-ratio: 4 / 3;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  position: relative;
+  overflow: clip;
+}
+
+.move-down_15percent {
+  transform: translate(0, 15%);
+}
+
+.move-up_50percent {
+  transform: translate(0, -50%);
+}
+
+.move-down_25percent {
+  transform: translate(0, 25%);
+}
+
+.margin-left_auto {
+  margin-left: auto;
+}
+
+.margin-left_small {
+  margin-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.image-ratio_1x1 {
+  aspect-ratio: 1;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  overflow: clip;
+}
+
+.form_success-message {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  border: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-accent);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20);
+}
+
+.form_error-message {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  background-color: #ff2b2b33;
+  border: 1px solid #ff565666;
+}
+
+.form_error-message_content {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  align-items: flex-start;
+  display: flex;
+}
+
+.padding-bottom_xxlarge {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x);
+}
+
+.height_50vh {
+  height: 50dvh;
+}
+
+.tag {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-horizontal);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-horizontal);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---tag--tag-size);
+  letter-spacing: .035em;
+  text-transform: uppercase;
+  color: inherit;
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
+  border: 1px solid #0000;
+  justify-content: center;
+  align-items: center;
+  padding: .15em .75em;
+  text-decoration: none;
+  transition-property: border-color, color, background-color;
+  transition-duration: .2s, .2s, .2s;
+  transition-timing-function: ease, ease, ease;
+  display: inline-flex;
+}
+
+.tag.is-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a80);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+}
+
+.tag.is-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+}
+
+.tag.on-accent-secondary {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.tag.on-accent-tertiary {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.image-ratio_2x2-5 {
+  aspect-ratio: 2 / 2.5;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  position: relative;
+  overflow: clip;
+}
+
+.padding-top_xxlarge {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x);
+}
+
+.content-block-link {
+  color: inherit;
+  text-decoration: none;
+  transition-property: opacity, color;
+  transition-duration: .3s, .3s;
+  transition-timing-function: ease, ease-in-out;
+  position: relative;
+}
+
+.content-block-link:hover {
+  color: color-mix(in srgb, currentColor 65%, transparent);
+}
+
+.tab_menu-button {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  color: inherit;
+  background-color: #0000;
+  font-size: .9375rem;
+  line-height: 1.3;
+}
+
+.tab_menu-button:hover {
+  color: inherit;
+  background-color: color-mix(in srgb, currentColor 5%, transparent);
+}
+
+.tab_menu-button.w--current {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-primary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+}
+
+.tab_menu-button.on-accent-primary.w--current {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+}
+
+.tab_menu-button.on-accent-primary.w--current:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+  opacity: .8;
+}
+
+.tab_menu-button.on-accent-secondary.w--current {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary);
+}
+
+.tab_menu-button.on-accent-secondary.w--current:hover {
+  opacity: .8;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary);
+}
+
+.tab_menu-button.on-accent-tertiary.w--current {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+}
+
+.tab_menu-button.on-accent-tertiary.w--current:hover {
+  opacity: .8;
+}
+
+.tab_menu-button.on-inverse:hover {
+  background-color: color-mix(in srgb, currentColor 20%, transparent);
+}
+
+.tab_menu-button.on-inverse.w--current:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover);
+  opacity: .8;
+}
+
+.tab_menu-button.is-expand {
+  flex: 1;
+}
+
+.radius_small {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+}
+
+.icon {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary);
+  vertical-align: middle;
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.icon.is-small {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+}
+
+.icon.is-xsmall {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.icon.is-xsmall.is-background {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+}
+
+.icon.on-inverse {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.icon.on-inverse.is-background {
+  background-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.icon.on-accent-primary, .icon.on-accent-secondary, .icon.on-accent-tertiary {
+  color: inherit;
+}
+
+.icon.is-background.on-inverse {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.icon.is-medium {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+}
+
+.icon.is-large {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+}
+
+.icon.is-xlarge {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+}
+
+.divider-vertical {
+  border-left-style: solid;
+  border-left-width: 1px;
+  border-left-color: color-mix(in srgb, currentColor 30%, transparent);
+  align-self: stretch;
+}
+
+.divider-vertical.is-secondary {
+  border-left-color: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.divider-vertical.is-accent {
+  border-left-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+}
+
+.overlay_opacity-middle {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-overlay);
+  opacity: .6;
+  position: absolute;
+  inset: 0%;
+}
+
+.overlay_opacity-middle.is-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  opacity: .75;
+}
+
+.text-button {
+  grid-column-gap: .5em;
+  grid-row-gap: .5em;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-weight);
+  flex: none;
+  justify-content: flex-start;
+  align-items: center;
+  text-decoration: none;
+  transition: all .2s ease-in-out;
+  display: inline-flex;
+}
+
+.text-button:hover {
+  grid-column-gap: .7em;
+  grid-row-gap: .7em;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover);
+}
+
+.text-button.is-small {
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+}
+
+.text-button.on-inverse {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-inverse);
+}
+
+.text-button.on-inverse:hover {
+  opacity: .7;
+}
+
+.text-button.is-secondary {
+  color: inherit;
+  transition-property: opacity, color;
+  transition-duration: .3s, .3s;
+  transition-timing-function: ease-in-out, ease-in-out;
+}
+
+.text-button.is-secondary:hover {
+  opacity: .6;
+}
+
+.text-button.on-accent-primary {
+  color: inherit;
+}
+
+.text-button.on-accent-primary:hover {
+  opacity: .6;
+  color: inherit;
+}
+
+.text-button.on-accent-tertiary, .text-button.on-accent-tertiary:hover, .text-button.on-accent-secondary, .text-button.on-accent-secondary:hover {
+  color: inherit;
+}
+
+.is-select {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-vertical);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-horizontal);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-vertical);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-horizontal);
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-right-style: solid;
+  border-right-width: 1px;
+  border-right-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-left-style: solid;
+  border-left-width: 1px;
+  border-left-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-text);
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: none;
+  background-position: 97%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+  height: auto;
+  margin-bottom: 0;
+  font-size: 1rem;
+  line-height: 1.3;
+  transition-property: background-color, border-color;
+  transition-duration: .2s, .2s;
+  transition-timing-function: cubic-bezier(.165, .84, .44, 1), cubic-bezier(.165, .84, .44, 1);
+}
+
+.is-select:hover {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border-hover);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-bg-hover);
+}
+
+.is-select:focus, .is-select:focus-visible, .is-select[data-wf-focus-visible] {
+  outline-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+}
+
+.is-select::placeholder {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-text-placeholder);
+}
+
+.radio_toggle {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  min-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  min-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: color-mix(in srgb, currentColor 70%, transparent);
+  border-right-color: color-mix(in srgb, currentColor 70%, transparent);
+  border-bottom-color: color-mix(in srgb, currentColor 70%, transparent);
+  border-left-color: color-mix(in srgb, currentColor 70%, transparent);
+  box-shadow: color-mix(in srgb, currentColor 0%, transparent) 0px 0px 0px 4px inset;
+  background-color: #0000;
+  border-radius: 50%;
+  margin-top: 0;
+  margin-left: -32px;
+  margin-right: 12px;
+  transition-property: box-shadow, border-color, background-color;
+  transition-duration: .2s, .2s, .2s;
+  transition-timing-function: ease-in-out, ease, ease;
+}
+
+.radio_toggle:hover {
+  box-shadow: color-mix(in srgb, currentColor 30%, transparent) 0px 0px 0px 4px;
+  border-top-color: color-mix(in srgb, currentColor 70%, transparent);
+  border-right-color: color-mix(in srgb, currentColor 70%, transparent);
+  border-bottom-color: color-mix(in srgb, currentColor 70%, transparent);
+  border-left-color: color-mix(in srgb, currentColor 70%, transparent);
+  background-color: #0000;
+}
+
+.radio_toggle.w--redirected-checked {
+  border-top-width: 6px;
+  border-top-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  border-right-width: 6px;
+  border-right-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  border-bottom-width: 6px;
+  border-bottom-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  border-left-width: 6px;
+  border-left-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: color-mix(in srgb, currentColor 70%, transparent) 0px 0px 0px 1px;
+  background-color: currentColor;
+}
+
+.radio_toggle.w--redirected-focus {
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+  outline-color: color-mix(in srgb, currentColor 40%, transparent);
+}
+
+.radio_toggle.w--redirected-focus-visible {
+  outline-offset: 2px;
+  outline-width: 2px;
+  outline-style: solid;
+  outline-color: color-mix(in srgb, currentColor 70%, transparent);
+}
+
+.radio_toggle.on-inverse {
+  border-width: 1px;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-inverse);
+  -webkit-text-stroke-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-border);
+}
+
+.radio_toggle.on-inverse:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-inverse-bg-hover);
+}
+
+.radio_toggle.on-inverse.w--redirected-checked {
+  border-width: 6px;
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-inverse);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+}
+
+.radio_toggle.on-accent-primary.w--redirected-checked {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+}
+
+.radio_toggle.on-accent-secondary.w--redirected-checked {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary-hover);
+}
+
+.background_accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+}
+
+.background_inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.background_secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+}
+
+.text-color_accent-primary {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+}
+
+.text-color_secondary {
+  color: color-mix(in srgb, currentColor 75%, transparent);
+}
+
+.text-color_inverse {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.text-color_inverse-secondary {
+  color: color-mix(in srgb, currentColor 70%, transparent);
+}
+
+.rotate_-12deg {
+  transform: rotate(-12deg);
+}
+
+.rotate_12deg {
+  transform: rotate(12deg);
+}
+
+.text-link {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary);
+  text-decoration: underline;
+  -webkit-text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
+  text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
+  font-weight: 400;
+  display: inline;
+}
+
+.text-link:hover {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary-hover);
+  text-decoration: underline;
+  -webkit-text-decoration-color: color-mix(in srgb, currentColor 100%, transparent);
+  text-decoration-color: color-mix(in srgb, currentColor 100%, transparent);
+}
+
+.text-link.is-small {
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+}
+
+.text-link.is-secondary {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-secondary);
+  text-decoration: underline;
+  -webkit-text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
+  text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.text-link.is-secondary:hover {
+  -webkit-text-decoration-color: color-mix(in srgb, currentColor 100%, transparent);
+  text-decoration-color: color-mix(in srgb, currentColor 100%, transparent);
+}
+
+.text-link.on-accent-primary {
+  color: inherit;
+}
+
+.text-link.on-accent-primary:hover {
+  opacity: .6;
+  color: inherit;
+}
+
+.text-link.on-accent-secondary {
+  color: inherit;
+}
+
+.text-link.on-accent-secondary:hover {
+  opacity: .6;
+  color: inherit;
+}
+
+.text-link.on-accent-tertiary {
+  color: inherit;
+}
+
+.text-link.on-accent-tertiary:hover {
+  opacity: .6;
+  color: inherit;
+}
+
+.text-link.on-inverse {
+  color: inherit;
+  text-decoration: underline;
+  -webkit-text-decoration-color: color-mix(in srgb, currentColor 50%, transparent);
+  text-decoration-color: color-mix(in srgb, currentColor 50%, transparent);
+}
+
+.text-link.on-inverse:hover {
+  opacity: .6;
+  color: inherit;
+  -webkit-text-decoration-color: color-mix(in srgb, currentColor 100%, transparent);
+  text-decoration-color: color-mix(in srgb, currentColor 100%, transparent);
+}
+
+.text-decoration_none {
+  text-decoration: none;
+}
+
+.width_medium {
+  width: 37.5rem;
+}
+
+.width_60percent {
+  width: 60%;
+}
+
+.width_35percent {
+  width: 35%;
+}
+
+.width_40percent {
+  width: 40%;
+}
+
+.filter_invert {
+  filter: invert();
+}
+
+.min-height_100percent {
+  min-height: 100%;
+}
+
+.checkbox {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  padding: 0px 0px 0px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  display: flex;
+  position: relative;
+}
+
+.checkbox_label {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+}
+
+.radio {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  padding: 0px 0px 0px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  display: flex;
+  position: relative;
+}
+
+.max-width_small {
+  max-width: 35rem;
+}
+
+.max-width_medium {
+  max-width: 40rem;
+}
+
+.max-width_large {
+  max-width: 50rem;
+}
+
+.dropdown_link {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.footer {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+}
+
+.footer.is-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+}
+
+.footer.is-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+}
+
+.footer.is-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.footer.is-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+}
+
+.footer.is-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+}
+
+.card-link {
+  border: 0px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-border);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20) inset, 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  opacity: 1;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+  flex-flow: column;
+  margin-bottom: 0;
+  text-decoration: none;
+  list-style-type: none;
+  transition: all .16s linear;
+  display: flex;
+  overflow: clip;
+  transform: translateY(0);
+}
+
+.card-link:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20) inset, 0 4px 6px #0000001a, 0 2px 0 #0000000d;
+  opacity: 1;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-text);
+  transform: translateY(-2px);
+}
+
+.card-link.on-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20) inset, 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  -webkit-text-stroke-color: black;
+  background-image: none;
+  border-color: #000000e6;
+}
+
+.card-link.on-secondary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20) inset, 0 4px 6px #0000001a, 0 2px 0 #0000000d;
+  color: #000;
+}
+
+.card-link.on-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20), 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  -webkit-text-stroke-color: black;
+  background-image: none;
+  border-color: #000000e6;
+}
+
+.card-link.on-accent-primary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20), 0 4px 6px #0000001a, 0 2px 0 #0000000d;
+  color: #000;
+}
+
+.card-link.on-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20) inset, 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  -webkit-text-stroke-color: black;
+  background-image: none;
+  border-color: #000000e6;
+}
+
+.card-link.on-inverse:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20) inset, 0 4px 6px #0000001a, 0 2px 0 #0000000d;
+  color: #000;
+}
+
+.card-link.on-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20), 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.card-link.on-accent-secondary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20), 0 4px 6px #0000001a, 0 2px 0 #0000000d;
+}
+
+.card-link.on-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20), 0 3px 3px #0000001a, 0 2px 0 #0000000d;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-image: none;
+}
+
+.card-link.on-accent-tertiary:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 0 0 1px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20), 0 4px 6px #0000001a, 0 2px 0 #0000000d;
+}
+
+.card-link.is-inverse {
+  border-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-border);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-inverse-text);
+}
+
+.width_auto {
+  width: auto;
+}
+
+.width_small {
+  width: 21rem;
+}
+
+.position_fixed {
+  position: fixed;
+}
+
+.position_fixed.is-top {
+  inset: 0% 0% auto;
+}
+
+.position_fixed.is-left {
+  left: 0;
+}
+
+.position_fixed.is-right {
+  right: 0;
+}
+
+.overflow_auto {
+  overflow: auto;
+}
+
+.z-index_2 {
+  z-index: 2;
+}
+
+.z-index_3 {
+  z-index: 3;
+}
+
+.z-index_4 {
+  z-index: 4;
+}
+
+.text-align_left {
+  text-align: left;
+}
+
+.icon_xsmall {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary);
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.padding-left_small {
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.padding-right_small {
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.radius_medium {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius);
+}
+
+.radius_large {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--lg-radius);
+}
+
+.radius_xlarge {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--xl-radius);
+}
+
+.margin-top_xlarge {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+}
+
+.margin-bottom_xlarge {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+}
+
+.margin_bottom-auto {
+  margin-bottom: auto;
+}
+
+.margin-left_xsmall {
+  margin-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+}
+
+.margin-left_medium {
+  margin-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.margin-right_auto {
+  margin-right: auto;
+}
+
+.padding-bottom_xlarge {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+}
+
+.padding-top_xlarge {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+}
+
+.z-index_5 {
+  z-index: 5;
+}
+
+.paragraph {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-size);
+}
+
+.logo {
+  grid-column-gap: .7rem;
+  grid-row-gap: .7rem;
+  color: inherit;
+  justify-content: flex-start;
+  align-items: center;
+  height: 2.5rem;
+  text-decoration: none;
+  display: flex;
+}
+
+.logo:hover {
+  color: color-mix(in srgb, currentColor 80%, transparent);
+}
+
+.logo.is-medium {
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.heading-responsive_large {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom);
+  font-size: 10cqw;
+  line-height: 1;
+}
+
+.heading-responsive_wrapper {
+  container-type: inline-size;
+}
+
+.ix_parallax-scale-out-hero {
+  position: absolute;
+  inset: 0%;
+  overflow: clip;
+}
+
+.flex_vertical {
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  flex-flow: column;
+  display: flex;
+}
+
+.flex_vertical.is_align-center-flex {
+  align-items: center;
+}
+
+.flex_vertical.gap-xsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+}
+
+.flex_vertical.gap-xxsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+}
+
+.flex_vertical.gap-large {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+}
+
+.flex_vertical.is_align-end-flex {
+  justify-content: flex-start;
+  align-items: flex-end;
+}
+
+.flex_vertical.gap-medium {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.flex_vertical.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.flex_vertical.is-y-center {
+  justify-content: center;
+  align-items: stretch;
+}
+
+.flex_vertical.gap-xlarge {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap);
+}
+
+.flex_vertical.is-x-center {
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.flex_vertical.is_disrection-inverse {
+  flex-flow: column-reverse;
+}
+
+.flex_vertical.is-x-left {
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
+.flex_vertical.is-justify_end {
+  justify-content: flex-end;
+}
+
+.overlay_opacity-low {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-overlay);
+  opacity: .4;
+  position: absolute;
+  inset: 0%;
+}
+
+.ix_trigger-100-vh {
+  width: 100%;
+  height: 100vh;
+}
+
+.ix_hero-scale-3x-to-1x-content {
+  z-index: 2;
+  position: relative;
+}
+
+.ix_hero-scale-3x-to-1x-overlay {
+  opacity: .65;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0%;
+}
+
+.heading-responsive_xlarge {
+  margin-bottom: .5em;
+  font-size: 12cqw;
+  line-height: 1.1em;
+}
+
+.background_accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary);
+}
+
+.background_accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+}
+
+.text-color_accent-secondary {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary);
+}
+
+.image-ratio_16x9 {
+  aspect-ratio: 16 / 9;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  position: relative;
+  overflow: clip;
+}
+
+.ix_custom_hero-to-place-wrapper {
+  flex: none;
+  height: clamp(300px, 40vw, 450px);
+}
+
+.nav_link {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  white-space: nowrap;
+  word-break: keep-all;
+  color: color-mix(in srgb, currentColor 75%, transparent);
+  flex: none;
+  justify-content: flex-start;
+  align-items: center;
+  padding: .5em .75em;
+  text-decoration: none;
+  display: flex;
+}
+
+.nav_link:hover {
+  background-color: color-mix(in srgb, currentColor 5%, transparent);
+  color: inherit;
+}
+
+.nav_link.w--current, .nav_link.w--open {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-bg-hover);
+}
+
+.nav_link.on-accent-primary {
+  background-color: inherit;
+}
+
+.nav_link.on-accent-primary:hover {
+  background-color: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.nav_link.on-accent-primary.w--current {
+  background-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.nav_link.on-accent-secondary:hover {
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.nav_link.on-accent-secondary.w--current {
+  background-color: color-mix(in srgb, currentColor 20%, transparent);
+}
+
+.nav_link.on-inverse {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-secondary);
+  background-color: color-mix(in srgb, currentColor 0%, transparent);
+}
+
+.nav_link.on-inverse:hover {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  background-color: color-mix(in srgb, currentColor 20%, transparent);
+}
+
+.nav_link.on-inverse.w--current {
+  background-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.footer_link {
+  grid-column-gap: .5em;
+  grid-row-gap: .5em;
+  color: color-mix(in srgb, currentColor 60%, transparent);
+  justify-content: flex-start;
+  align-items: center;
+  padding-top: .35em;
+  padding-bottom: .35em;
+  font-weight: 400;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.footer_link:hover {
+  opacity: 1;
+  color: color-mix(in srgb, currentColor 100%, transparent);
+  text-decoration: underline;
+}
+
+.footer_link.on-inverse, .footer_link.on-inverse:hover {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---nav-link--nav-link-inverse);
+}
+
+.flex-align_bottom {
+  align-self: flex-end;
+}
+
+.flex-align_center {
+  align-self: center;
+}
+
+.ix_marquee-horizontal {
+  flex: none;
+  display: flex;
+  position: relative;
+}
+
+.custom_marquee-horizontal-wrapper {
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  flex: none;
+  justify-content: flex-start;
+  align-items: stretch;
+  position: relative;
+}
+
+.ix_hero-intro-down-scale-3d.is-perspective {
+  perspective: 2000px;
+}
+
+.ix_hero-intro-slide-up-variable {
+  transform: translate(0px, var(--ix--ix-hero-intro-slide-up-100vh));
+  transition-property: transform;
+  transition-duration: .2s;
+  transition-timing-function: cubic-bezier(.075, .82, .165, 1);
+  position: relative;
+}
+
+.ix_hero-intro-slide-up-variable.is-step-2-intro-slide-up-variable {
+  transition-duration: 1s;
+  transition-timing-function: cubic-bezier(.075, .82, .165, 1);
+}
+
+.ix_hero-intro-slide-up-variable.is-step-3-intro-slide-up-variable {
+  transition-duration: 1.2s;
+}
+
+.ix_hero-intro-slide-up-variable.is-step-4-intro-slide-up-variable {
+  transition-duration: 1.4s;
+}
+
+.ix_hero-intro-slide-up-variable.is-step-5-intro-slide-up-variable {
+  transition-duration: 1.6s;
+}
+
+.ix_hero-intro-slide-up-variable.is-line-3-intro-slide-up-variable {
+  transition-duration: 2.5s;
+}
+
+.ix_hero-intro-slide-up-variable.is-line-2-intro-slide-up-variable {
+  transition-duration: 2s;
+}
+
+.ix_hero-intro-slide-up-variable.is-line-1-intro-slide-up-variable {
+  transition-duration: 1.5s;
+}
+
+.ix_hero-intro-text-stack {
+  position: relative;
+}
+
+.ix_hero-intro-clip-mask {
+  -webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0% 100%);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0% 100%);
+  position: relative;
+}
+
+.ix_hero-intro-clip-mask.is-element-3-hero-intro-clip-mask {
+  clip-path: polygon(0 var(--ix--ix-hero-intro-clipping-mask-3), 100% var(--ix--ix-hero-intro-clipping-mask-3), 100% 100%, 0% 100%);
+}
+
+.ix_hero-intro-clip-mask.is-element-2-hero-intro-clip-mask {
+  clip-path: polygon(0 var(--ix--ix-hero-intro-clipping-mask-2), 100% var(--ix--ix-hero-intro-clipping-mask-2), 100% 100%, 0% 100%);
+}
+
+.ix_hero-intro-clip-mask.is-element-1-hero-intro-clip-mask {
+  clip-path: polygon(0 var(--ix--ix-hero-intro-clipping-mask-2), 100% var(--ix--ix-hero-intro-clipping-mask-2), 100% 100%, 0% 100%);
+  align-self: stretch;
+}
+
+.ix_hero-intro-slide-up-100vh {
+  position: relative;
+}
+
+.ix_slider-slide-up {
+  overflow: hidden;
+}
+
+.ix_hero-overlap-parallax-trigger {
+  margin-top: -30vh;
+}
+
+.overflow_clip {
+  overflow: clip;
+}
+
+.sg_main-wrapper {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  width: 100%;
+  min-height: 100%;
+  display: block;
+  overflow: clip;
+}
+
+.sg_page-content {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+  flex: 1;
+  margin-left: 200px;
+}
+
+.sg_navigation {
+  flex-flow: column;
+  align-self: stretch;
+  width: 200px;
+  height: 100%;
+  display: flex;
+  position: fixed;
+}
+
+.sg_logo {
+  z-index: 2;
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  flex-flow: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  font-size: 1rem;
+  line-height: 1;
+  text-decoration: none;
+  display: flex;
+}
+
+.sg_logo.w--current {
+  align-items: center;
+}
+
+.sg_nav-menu {
+  flex-flow: column;
+  flex: 1;
+  justify-content: flex-start;
+  align-items: stretch;
+  height: 100px;
+  display: flex;
+  overflow: auto;
+}
+
+.sg_nav-menu-item {
+  padding: .125rem var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x) .125rem .5rem;
+  border-left: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-secondary);
+  margin-left: 1rem;
+  font-size: .875rem;
+  text-decoration: none;
+  transition: all .2s;
+  display: block;
+}
+
+.sg_nav-menu-item:hover, .sg_nav-menu-item.w--current {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary);
+}
+
+.sg_nav-menu-item.w--current:focus-visible, .sg_nav-menu-item.w--current[data-wf-focus-visible] {
+  text-decoration: underline;
+}
+
+.sg_nav-subheading {
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-line-height);
+  margin-bottom: 0;
+}
+
+.sg_nav-menu-group {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  flex-flow: column;
+  display: flex;
+}
+
+.sg_nav-menu-heading {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  text-decoration: none;
+  transition: all .2s;
+}
+
+.sg_nav-menu-heading.w--current:focus-visible, .sg_nav-menu-heading.w--current[data-wf-focus-visible] {
+  text-decoration: underline;
+}
+
+.sg_section-heading-wrapper {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  flex-flow: column;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-columns: 1fr;
+  justify-content: space-between;
+  align-items: flex-start;
+  display: flex;
+}
+
+.flex-child_expand {
+  flex: 1;
+}
+
+.sg_card-wrapper {
+  grid-column-gap: 1rem;
+  grid-row-gap: 1rem;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---card--card-primary-bg);
+  flex-flow: column;
+  padding: 2rem;
+  display: flex;
+}
+
+.sg_card-wrapper.sg_card-invert {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.sg_card-wrapper.sg_card-accent-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  -webkit-text-stroke-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+}
+
+.sg_card-wrapper.sg_card-secondary {
+  border: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-primary);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-secondary);
+}
+
+.sg_card-wrapper.sg_card-accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  -webkit-text-stroke-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+}
+
+.sg_card-wrapper.sg_card-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  -webkit-text-stroke-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  box-shadow: inset 0 0 0 1px #7777774f;
+}
+
+.sg_table-row {
+  flex: 1;
+  display: flex;
+}
+
+.sg_table-row.sg_table-head {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  border-bottom: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+}
+
+.sg_table-row.sg_border-bottom {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  border-bottom: 1px solid #7776;
+}
+
+.sg_table-row.sg_gap {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.sg_table-cell-title {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  opacity: .7;
+  flex-flow: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 10rem;
+  font-size: .75rem;
+  display: flex;
+}
+
+.sg_table-cell {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  flex-flow: column;
+  flex: 1;
+  justify-content: center;
+  align-self: stretch;
+  align-items: flex-start;
+  display: flex;
+}
+
+.sg_table-cell.sg_cell-small {
+  max-width: 8rem;
+}
+
+.sg_table-cell.sg_align-bottom {
+  justify-content: flex-end;
+  align-items: flex-start;
+}
+
+.sg_table-cell.sg_preview-lg {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-template-rows: auto;
+  grid-template-columns: 1fr;
+  grid-auto-columns: 1fr;
+  justify-content: flex-start;
+  place-items: start stretch;
+  min-height: 15rem;
+  display: grid;
+}
+
+.sg_color-sample {
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border: 1px #7777777d;
+  border-radius: 0;
+  flex: 1;
+  justify-content: flex-start;
+  align-items: flex-end;
+  min-height: 3rem;
+  padding: .5rem;
+  font-size: .75rem;
+  line-height: 1.1;
+  display: flex;
+  position: relative;
+}
+
+.sg_color-sample.sg_primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  border-style: none;
+}
+
+.sg_color-sample.sg_primary-a90 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a90);
+}
+
+.sg_color-sample.sg_primary-hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary-hover);
+  border-style: none;
+}
+
+.sg_color-sample.sg_primary-a80 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a80);
+}
+
+.sg_color-sample.sg_primary-a70 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a70);
+}
+
+.sg_color-sample.sg_primary-a60 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a60);
+}
+
+.sg_color-sample.sg_primary-a50 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a50);
+}
+
+.sg_color-sample.sg_primary-a40 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a40);
+}
+
+.sg_color-sample.sg_primary-a30 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a30);
+}
+
+.sg_color-sample.sg_primary-a20 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a20);
+}
+
+.sg_color-sample.sg_primary-a10 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a10);
+}
+
+.sg_color-sample.sg_secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary);
+  border-style: none;
+}
+
+.sg_color-sample.sg_secondary-hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-secondary-hover);
+  border-style: none;
+}
+
+.sg_color-sample.sg_secondary-a90 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a90);
+}
+
+.sg_color-sample.sg_secondary-a80 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a80);
+}
+
+.sg_color-sample.sg_secondary-a70 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a70);
+}
+
+.sg_color-sample.sg_secondary-a60 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a60);
+}
+
+.sg_color-sample.sg_secondary-a50 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a50);
+}
+
+.sg_color-sample.sg_secondary-a40 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a40);
+}
+
+.sg_color-sample.sg_secondary-a30 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a30);
+}
+
+.sg_color-sample.sg_secondary-a20 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a20);
+}
+
+.sg_color-sample.sg_secondary-a10 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-secondary-a10);
+}
+
+.sg_color-sample.sg_tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-tertiary);
+  border-style: none;
+}
+
+.sg_color-sample.sg_tertiary-hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-tertiary-hover);
+  border-style: none;
+}
+
+.sg_color-sample.sg_tertiary-a90 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a90);
+}
+
+.sg_color-sample.sg_core-primary-a90 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a90);
+}
+
+.sg_color-sample.sg_core-primary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-inverse);
+}
+
+.sg_color-sample.sg_core-primary-a80 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a80);
+}
+
+.sg_color-sample.sg_core-primary-a70 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a70);
+}
+
+.sg_color-sample.sg_core-primary-a60 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a60);
+}
+
+.sg_color-sample.sg_core-primary-a50 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a50);
+}
+
+.sg_color-sample.sg_core-primary-a40 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a40);
+}
+
+.sg_color-sample.sg_core-primary-a30 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+}
+
+.sg_color-sample.sg_core-primary-a20 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a20);
+}
+
+.sg_color-sample.sg_core-primary-a10 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10);
+}
+
+.sg_color-sample.sg_core-inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-primary);
+  border-top-style: none;
+  border-left-style: none;
+  border-right-style: none;
+}
+
+.sg_color-sample.sg_core-inverse-a90 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a90);
+}
+
+.sg_color-sample.sg_core-inverse-a80 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a80);
+}
+
+.sg_color-sample.sg_core-inverse-a70 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a70);
+}
+
+.sg_color-sample.sg_core-inverse-a60 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a60);
+}
+
+.sg_color-sample.sg_core-inverse-a50 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a50);
+}
+
+.sg_color-sample.sg_core-inverse-a40 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a40);
+}
+
+.sg_color-sample.sg_core-inverse-a30 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a30);
+}
+
+.sg_color-sample.sg_core-inverse-a20 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a20);
+}
+
+.sg_color-sample.sg_core-inverse-a10 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-primary-a10);
+}
+
+.sg_color-sample.sg_tertiary-a10 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a10);
+}
+
+.sg_color-sample.sg_tertiary-a20 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a20);
+}
+
+.sg_color-sample.sg_tertiary-a30 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a30);
+}
+
+.sg_color-sample.sg_tertiary-a40 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a40);
+}
+
+.sg_color-sample.sg_tertiary-a50 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a50);
+}
+
+.sg_color-sample.sg_tertiary-a60 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a60);
+}
+
+.sg_color-sample.sg_tertiary-a70 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a70);
+}
+
+.sg_color-sample.sg_tertiary-a80 {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-tertiary-a80);
+}
+
+.sg_color-sample.sg_core-neutral {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-neutral-color--neutral-secondary);
+  border-style: none;
+}
+
+.sg_table-header-heading {
+  opacity: .6;
+  font-size: .75rem;
+  line-height: 1.5;
+}
+
+.sg_divider {
+  border-top: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+  opacity: .5;
+  -webkit-text-stroke-width: 0px;
+}
+
+.sg_spacing {
+  border-right: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-accent);
+  border-left: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-accent);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a30);
+  height: 1.75rem;
+}
+
+.sg_spacing.sg_gap-xxs {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+}
+
+.sg_spacing.sg_gap-xs {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+}
+
+.sg_spacing.sg_gap-sm {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.sg_spacing.sg_gap-md {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.sg_spacing.sg_gap-lg {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+}
+
+.sg_spacing.sg_gap-xl {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap);
+}
+
+.sg_spacing.sg_gap-xxl {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap);
+}
+
+.sg_spacing-demo {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a10);
+  flex: 1;
+  width: 5rem;
+  height: 1.75rem;
+}
+
+.sg_table-col {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  flex-flow: column;
+  flex: 10rem;
+  display: flex;
+}
+
+.sg_text-muted {
+  opacity: .5;
+}
+
+.sg_preview-solid {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  justify-content: center;
+  align-self: stretch;
+  align-items: center;
+  width: 100%;
+  min-height: 10rem;
+  padding: 1rem;
+  display: flex;
+  position: relative;
+}
+
+.shadow_xxsmall {
+  box-shadow: 0 1px 2px #0000001a;
+}
+
+.shadow_xsmall {
+  box-shadow: 0 2px 4px #0000001a;
+}
+
+.shadow_small {
+  box-shadow: 0 2px 6px #0000001a;
+}
+
+.shadow_medium {
+  box-shadow: 0 4px 8px #0000001a;
+}
+
+.shadow_large {
+  box-shadow: 0 4px 16px #0000001a;
+}
+
+.shadow_xlarge {
+  box-shadow: 0 6px 24px #0000001a;
+}
+
+.shadow_xxlarge {
+  box-shadow: 0 6px 32px #0000001a;
+}
+
+.sg_preview-solid-inverse {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+  justify-content: center;
+  align-self: stretch;
+  align-items: center;
+  width: 100%;
+  min-height: 10rem;
+  padding: 1rem;
+  display: flex;
+  position: relative;
+}
+
+.sg_preview-solid-accent {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+  flex-flow: wrap;
+  justify-content: center;
+  align-self: stretch;
+  align-items: center;
+  width: 100%;
+  min-height: 10rem;
+  padding: 1rem;
+  display: flex;
+}
+
+.sg_preview-solid-accent.sg_accent-secondary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-secondary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+}
+
+.sg_preview-solid-accent.sg-accent-tertiary {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-accent-tertiary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-tertiary);
+}
+
+.sg_preview-solid-accent.sg_inverse {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-inverse-primary);
+}
+
+.events_none {
+  pointer-events: none;
+}
+
+.sg_col {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  flex-flow: column;
+  display: flex;
+}
+
+.sg_hidden-element {
+  display: none;
+}
+
+.sg_group-hero {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  border-top: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+}
+
+.sg_group-hero.sg_first {
+  border-top-style: none;
+  border-top-width: 0;
+}
+
+.sg_section-border {
+  border-style: dashed;
+  border-width: 2px;
+  border-top-color: color-mix(in srgb, currentColor 60%, transparent);
+  border-right-color: color-mix(in srgb, currentColor 60%, transparent);
+  border-bottom-color: color-mix(in srgb, currentColor 60%, transparent);
+  border-left-color: color-mix(in srgb, currentColor 60%, transparent);
+}
+
+.sg_section-border.padding_large.text-align_center {
+  border-top-color: color-mix(in srgb, currentColor 50%, transparent);
+  border-right-color: color-mix(in srgb, currentColor 50%, transparent);
+  border-bottom-color: color-mix(in srgb, currentColor 50%, transparent);
+  border-left-color: color-mix(in srgb, currentColor 50%, transparent);
+}
+
+.tag_group {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  background-color: #0000;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+  display: flex;
+}
+
+.ix_sticky-card {
+  position: sticky;
+  top: 0;
+}
+
+.ix_rotate-to-cw-10 {
+  perspective-origin: 100% 100%;
+  transform-origin: 100% 100%;
+}
+
+.max-width_xsmall {
+  max-width: 20rem;
+}
+
+.ix_rotate-to-ccw-10 {
+  perspective-origin: 0 100%;
+  transform-origin: 0 100%;
+}
+
+.ix_card-slide-up {
+  transition: opacity .3s cubic-bezier(.55, .055, .675, .19), transform .3s cubic-bezier(.55, .055, .675, .19);
+}
+
+.custom_target-image {
+  transition: transform .3s ease-in-out;
+  transform: translate(100%);
+}
+
+.custom_target-image.w--current {
+  transform: translate(0%);
+}
+
+.custom_change-height-link {
+  flex-flow: column;
+  height: 0;
+  transition: max-height .3s ease-in-out;
+  display: flex;
+}
+
+.custom_change-height-link.w--current {
+  color: inherit;
+  text-decoration: none;
+}
+
+.ix_full-screen-background {
+  width: 80vw;
+  min-width: 100%;
+  min-height: 100%;
+  position: absolute;
+  top: 0;
+  overflow: clip;
+}
+
+.heading-responsive {
+  margin-bottom: .5em;
+  font-size: 7cqw;
+  line-height: 1;
+}
+
+.ix_card-stack-1, .ix_card-stack-2, .ix_card-stack-3 {
+  position: relative;
+}
+
+.ix_card-stack-explode-card {
+  pointer-events: auto;
+  display: flex;
+}
+
+.ix_card-stack-explode-card.is-ix-1 {
+  transform: translate(-20vw, -20vh);
+}
+
+.ix_card-stack-explode-card.is-ix-2 {
+  transform: translate(0, -20vh);
+}
+
+.ix_card-stack-explode-card.is-ix-3 {
+  transform: translate(10vw, -10vh);
+}
+
+.ix_card-stack-explode-card.is-ix-4 {
+  transform: translate(-10vw, 10vh);
+}
+
+.ix_card-stack-explode-card.is-ix-5 {
+  transform: translate(0, 20vh);
+}
+
+.ix_card-stack-explode-card.is-ix-6 {
+  transform: translate(20vw, 10vh);
+}
+
+.ix_card-rotate-left {
+  transform-origin: 0 100%;
+}
+
+.ix_card-rotate-right {
+  transform-origin: 100% 100%;
+}
+
+.ix_card-change-width {
+  min-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-card-change-width);
+  flex: 1;
+  margin-right: 1rem;
+}
+
+.ix_card-change-width-trigger {
+  overflow: clip;
+}
+
+.ix_card-change-width-background {
+  object-fit: cover;
+  width: 10vw;
+  min-width: 100%;
+  max-width: none;
+  height: 10vh;
+  min-height: 100%;
+  position: absolute;
+}
+
+.ix_card-background {
+  overflow: clip;
+}
+
+.tabs_content {
+  overflow: visible;
+}
+
+.nav_container {
+  max-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-width);
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-padding-horizontal);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: #ddd0;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr;
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+}
+
+.nav_left {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  flex: 1;
+  justify-content: flex-start;
+  align-items: center;
+  display: flex;
+}
+
+.nav_right {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  flex: 1;
+  justify-content: flex-end;
+  align-items: center;
+  display: flex;
+}
+
+.nav_logo {
+  grid-column-gap: .5rem;
+  grid-row-gap: .5rem;
+  color: inherit;
+  justify-content: flex-start;
+  align-items: center;
+  height: 2.5rem;
+  text-decoration: none;
+  display: flex;
+}
+
+.nav_logo:hover {
+  color: color-mix(in srgb, currentColor 80%, transparent);
+}
+
+.nav_menu-full-screen {
+  z-index: 1;
+  text-align: left;
+  justify-content: center;
+  align-self: center;
+  align-items: center;
+  height: 100dvh;
+  margin-bottom: 0;
+  display: flex;
+  position: fixed;
+  inset: 0%;
+}
+
+.ix_nav-cover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+  pointer-events: none;
+  transform-origin: 50% 100%;
+  transform-style: preserve-3d;
+  height: 100%;
+  position: absolute;
+  inset: 0% 0% auto;
+  transform: scale3d(1, 0, 1);
+}
+
+.mask_left {
+  -webkit-mask-image: linear-gradient(to left, #000 20%, #0000001a 100%);
+  mask-image: linear-gradient(to left, #000 20%, #0000001a 100%);
+}
+
+.mask_right {
+  -webkit-mask-image: linear-gradient(to right, #000 20%, #0000001a 100%);
+  mask-image: linear-gradient(to right, #000 20%, #0000001a 100%);
+}
+
+.mask_bottom {
+  -webkit-mask-image: linear-gradient(#000 20%, #0000001a 100%);
+  mask-image: linear-gradient(#000 20%, #0000001a 100%);
+}
+
+.mask_top {
+  -webkit-mask-image: linear-gradient(to top, #000 20%, #0000001a 100%);
+  mask-image: linear-gradient(to top, #000 20%, #0000001a 100%);
+}
+
+.is-background {
+  box-sizing: content-box;
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-primary);
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.is-background.on-accent-primary, .is-background.on-accent-secondary, .is-background.on-accent-tertiary {
+  color: inherit;
+}
+
+.is-background.on-inverse {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-accent-on-inverse);
+}
+
+.button_icon {
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  width: 1em;
+  height: 1em;
+  display: inline-flex;
+}
+
+.image {
+  object-fit: contain;
+  width: 100%;
+}
+
+.image.image_cover {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.radius_top-0 {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.radius_bottom-0 {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.radius_all-0 {
+  border-radius: 0;
+  border-radius: 0 !important;
+}
+
+.radius_left-0 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.subheading {
+  max-width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-sm-width);
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  font-family: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size);
+  line-height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-line-height);
+  letter-spacing: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-letter-spacing);
+  color: color-mix(in srgb, currentColor 70%, transparent);
+  text-wrap: balance;
+}
+
+.subheading p {
+  letter-spacing: 0;
+  font-size: inherit;
+  margin-bottom: inherit;
+}
+
+.sg_accent-secondary-visibility, .sg_accent-tertiary-visibility {
+  display: none;
+}
+
+.nav_mobile-menu_button-wrapper {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: relative;
+}
+
+.on-inverse.is-background {
+  background-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.sg_wrapper {
+  position: relative;
+}
+
+.sg_colors-column {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  flex-flow: column;
+  flex: 1;
+  display: flex;
+  position: relative;
+}
+
+.sg_colors-column.sg_main {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+}
+
+.nav_logo-icon {
+  align-self: stretch;
+  display: flex;
+}
+
+.radius_right-0 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.sg_color-combo {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border: 1px solid #7773;
+  flex-flow: column;
+  flex: 1;
+  min-height: 12rem;
+  display: flex;
+  overflow: clip;
+}
+
+.radius_card {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+}
+
+.radius_button {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius);
+}
+
+.dropdown {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.dropdown_toggle {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal);
+  grid-column-gap: .7em;
+  grid-row-gap: .7em;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  justify-content: flex-start;
+  align-items: center;
+  font-weight: 700;
+  line-height: 1.2;
+  transition: border-color .2s, background-color .2s;
+  display: flex;
+}
+
+.dropdown_toggle:hover {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-bg-hover);
+}
+
+.dropdown_toggle.w--open {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.dropdown_list.w--open {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 2px 6px #0000001a;
+}
+
+.dropdown_list.is-open_up.w--open {
+  bottom: 100%;
+}
+
+.dropdown_list.is-open_up-left.w--open {
+  bottom: 100%;
+  right: 0;
+}
+
+.dropdown_list.is-open_left.w--open {
+  right: 0;
+}
+
+.card_body_small {
+  z-index: 1;
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  flex-flow: column;
+  min-height: 100%;
+  display: flex;
+  position: relative;
+}
+
+.sg_code-embed {
+  z-index: 99;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  position: fixed;
+  inset: auto auto 0% 0%;
+}
+
+.mask_fade-horizontal {
+  -webkit-mask-image: linear-gradient(to right, #0000 0%, #000 10% 90%, #0000 100%);
+  mask-image: linear-gradient(to right, #0000 0%, #000 10% 90%, #0000 100%);
+}
+
+.tab_menu-link_transparent-bottom {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical);
+  padding-right: 0;
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical);
+  box-shadow: inset 0 2px 0 0 var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a30);
+  opacity: .5;
+  color: inherit;
+  background-color: #0000;
+  border-radius: 0;
+  padding-left: 0;
+  font-size: .9375rem;
+  line-height: 1.3;
+}
+
+.tab_menu-link_transparent-bottom:hover {
+  opacity: .7;
+  color: inherit;
+  background-color: #0000;
+}
+
+.tab_menu-link_transparent-bottom.w--current {
+  box-shadow: inset 0 2px 0 0 var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--neutral-inverse-a70);
+  opacity: 100;
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  background-color: #fff0;
+}
+
+.tab_menu-link {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal);
+  opacity: .5;
+  color: inherit;
+  box-shadow: color-mix(in srgb, currentColor 30%, transparent) 0px -2px 0px 0px inset;
+  background-color: #0000;
+  border-radius: 0;
+  font-size: .9375rem;
+  line-height: 1.3;
+}
+
+.tab_menu-link:hover {
+  opacity: .7;
+  color: inherit;
+  box-shadow: color-mix(in srgb, currentColor 50%, transparent) 0px -2px 0px 0px inset;
+  background-color: #0000;
+}
+
+.tab_menu-link.w--current {
+  opacity: 100;
+  box-shadow: color-mix(in srgb, currentColor 70%, transparent) 0px -2px 0px 0px inset;
+  background-color: #0000;
+}
+
+.backdrop-filter_blur {
+  -webkit-backdrop-filter: blur(50px);
+  backdrop-filter: blur(50px);
+}
+
+.text-button_icon {
+  color: inherit;
+  justify-content: center;
+  align-items: center;
+  width: 1em;
+  height: 1em;
+  display: flex;
+}
+
+.padding-horizontal_none, .padding-vertical_none {
+  padding-left: 0;
+  padding-right: 0;
+  list-style-type: none;
+}
+
+.padding-left_medium {
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.ix_backdrop-filter-blur {
+  will-change: auto !important;
+  filter: none !important;
+  transform-style: unset !important;
+}
+
+.custom_transition-opacity {
+  transition: opacity .4s ease-in-out;
+}
+
+.text-color_on-accent-primary {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-primary);
+}
+
+.text-color_on-accent-secondary {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-accent-secondary);
+}
+
+.mask_fade-vertical {
+  -webkit-mask-image: linear-gradient(to top, #0000 0%, #000 10% 90%, #0000 100%);
+  mask-image: linear-gradient(to top, #0000 0%, #000 10% 90%, #0000 100%);
+}
+
+.sg_grid {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  flex: 1;
+  grid-template-rows: auto;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  grid-auto-columns: minmax(15rem, 1fr);
+  place-items: stretch stretch;
+  display: grid;
+}
+
+.sg_color-col-inverse {
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  box-shadow: 0 0 0 8px var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-inverse);
+  flex-flow: column;
+  flex: 1;
+  margin-left: .5rem;
+  margin-right: .5rem;
+  display: flex;
+  overflow: clip;
+}
+
+.sg_color-col {
+  grid-column-gap: 0rem;
+  grid-row-gap: 0rem;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border: 1px solid #77777730;
+  flex-flow: column;
+  flex: 1;
+  display: flex;
+  overflow: clip;
+}
+
+.accordion_body {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.sg_heading-row {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  justify-content: space-between;
+  align-self: stretch;
+  align-items: baseline;
+  display: flex;
+}
+
+.sg_grid-buttons {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  flex: 1;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-auto-columns: minmax(15rem, 1fr);
+  align-self: stretch;
+  place-items: center start;
+  display: grid;
+}
+
+.sg_height-auto {
+  min-height: 5rem;
+}
+
+.padding-right_medium {
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.sg_table-head {
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  border-bottom: 1px solid var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---border-color--border-secondary);
+}
+
+.grid_3-col {
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.gap-xsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+}
+
+.gap-xxsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+}
+
+.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.gap-medium {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.gap-large {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+}
+
+.gap-xlarge {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap);
+}
+
+.gap-xxlarge {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap);
+}
+
+.grid_9-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.grid_9-col.gap-xsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+}
+
+.grid_6-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.grid_6-col.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.grid_6-col.gap-xsmall {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+}
+
+.grid_5-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.grid_5-col.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.grid_5-col.gap-medium {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.grid_4-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.grid_4-col.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.grid_4-col.gap-xsmall {
+  grid-column-gap: 1rem;
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-column-gap: 1rem;
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+}
+
+.grid_1-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr);
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.grid_1-col.gap-medium {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+}
+
+.grid_1-col.gap-small {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+}
+
+.grid_12-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.grid_8-col {
+  grid-template-rows: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.is-y-top {
+  place-items: start stretch;
+}
+
+.gap-0 {
+  grid-column-gap: 0rem;
+  grid-row-gap: 0rem;
+}
+
+.grid_auto {
+  grid-column-gap: 16px;
+  grid-row-gap: 16px;
+  grid-template-rows: auto;
+  grid-template-columns: repeat(auto-fit, 100%);
+  grid-auto-columns: 100%;
+  grid-auto-flow: column;
+  display: grid;
+}
+
+.ix_card-deck-space {
+  margin-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_interactions---ix--ix-card-spacing);
+  transition: margin-right .3s ease-in-out;
+}
+
+.tabs_nav {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  justify-content: flex-start;
+  align-items: center;
+  display: flex;
+}
+
+.tabs_nav.is-bottom {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  margin-bottom: 0;
+}
+
+.is-y-center {
+  place-items: center stretch;
+}
+
+.is-y-bottom {
+  align-items: end;
+}
+
+.is-y-baseline {
+  align-items: baseline;
+}
+
+.text-width_medium {
+  max-width: 75ch;
+}
+
+.text-width_small {
+  max-width: 50ch;
+}
+
+.text-width_xsmall {
+  max-width: 40ch;
+}
+
+.text-width_xxsmall {
+  max-width: 20ch;
+}
+
+.image-ratio_auto {
+  aspect-ratio: auto;
+  border-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: clip;
+}
+
+.ratio_16x9 {
+  aspect-ratio: 16 / 9;
+}
+
+.ratio_3x2 {
+  aspect-ratio: 3 / 2;
+}
+
+.ratio_4x3 {
+  aspect-ratio: 4 / 3;
+}
+
+.ratio_1x1 {
+  aspect-ratio: 1;
+}
+
+.ratio_2x3 {
+  aspect-ratio: 2 / 3;
+}
+
+.nav_center {
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: static;
+}
+
+.nav_menu {
+  background-color: #0000;
+  justify-content: center;
+  align-self: center;
+  align-items: center;
+  height: 100%;
+  margin-bottom: 0;
+  padding-left: 0;
+  display: flex;
+  position: static;
+}
+
+.nav_menu-list {
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  flex-flow: row;
+  margin-bottom: 0;
+  padding-left: 0;
+  display: flex;
+}
+
+.nav_menu-list-item {
+  margin-bottom: 0;
+  display: flex;
+}
+
+.nav_dropdown-menu {
+  position: static;
+}
+
+.nav-caret {
+  margin: 0;
+  position: relative;
+}
+
+.mega-nav_dropdown-list.w--open {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  background-color: #0000;
+  left: 0;
+  right: 0;
+}
+
+.mega-nav_dropdown-list-wrapper {
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  grid-template-rows: auto auto;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-columns: 1fr;
+  width: 100%;
+  padding: 2rem;
+  box-shadow: 0 4px 8px -2px #0000001a;
+}
+
+.mega-nav_dropdown-list-wrapper.w--open {
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  order: 0;
+  justify-content: center;
+  align-self: auto;
+  padding: 2rem;
+  display: flex;
+  position: absolute;
+  inset: 100% 0% auto;
+  box-shadow: 0 8px 8px -4px #0000001a;
+}
+
+.mega-nav_list {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-template-rows: auto;
+  grid-template-columns: 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.mega-nav_link-item {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  text-decoration: none;
+  transition: color .2s;
+  display: flex;
+}
+
+.nav_dropdown-list.w--open {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+  background-color: #0000;
+  display: flex;
+}
+
+.nav-menu_dropdown-list-wrapper {
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+  box-shadow: 0 4px 8px #0000001a;
+}
+
+.nav-menu_dropdown-list-wrapper.w--open {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  top: 100%;
+  box-shadow: 0 6px 8px -4px #0000001a;
+}
+
+.nav_dropdown-link {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---nav-link--nav-link-primary);
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-weight);
+  justify-content: flex-start;
+  align-items: center;
+  padding: .75em 1em;
+  text-decoration: none;
+  transition: color .2s;
+  display: flex;
+}
+
+.nav_dropdown-link.w--current, .nav_dropdown-link.w--open {
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-bg-hover);
+}
+
+.button_label {
+  white-space: pre;
+}
+
+.padding_none {
+  padding: 0;
+  list-style-type: none;
+}
+
+.min-height_100dvh {
+  min-height: 100dvh;
+}
+
+.header.is-2-col {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.header {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  flex-flow: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  display: flex;
+}
+
+.header {
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap);
+  flex-flow: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  display: flex;
+}
+
+.header.is-align-center {
+  text-align: center;
+  align-items: center;
+  display: flex;
+}
+
+.text-color_on-overlay {
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-on-overlay);
+}
+
+.text_all-caps {
+  text-transform: uppercase;
+}
+
+.footer_icon-group {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  background-color: #0000;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 0;
+  display: flex;
+}
+
+.footer_icon-link {
+  width: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  height: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  color: color-mix(in srgb, currentColor 70%, transparent);
+  justify-content: center;
+  align-items: center;
+  padding: .35rem;
+  display: inline-flex;
+}
+
+.footer_bottom {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  justify-content: space-between;
+  align-items: center;
+  display: flex;
+}
+
+.margin_none {
+  margin: 0;
+}
+
+.max-height_100vh_desktop {
+  max-height: 100dvh;
+}
+
+.margin-horizontal_auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.position_sticky-bottom {
+  position: sticky;
+  bottom: 0;
+}
+
+.offset_bottom-30vh {
+  margin-bottom: -30vh;
+}
+
+.ix_rotate-to-cw-30 {
+  perspective-origin: 0 100%;
+  transform-origin: 0 100%;
+  width: 100%;
+}
+
+.ix_rotate-from-to {
+  perspective-origin: 0%;
+  transform-origin: 0%;
+  justify-content: flex-end;
+  align-items: center;
+  display: flex;
+  position: relative;
+  left: -25%;
+  transform: perspective(2000px);
+}
+
+.ix_sticky-height-expand-3, .ix_sticky-height-expand-1 {
+  transform-origin: 0 0;
+}
+
+.ix_sticky-height-expand-right {
+  transform-origin: 100% 100%;
+}
+
+.ix_sticky-height-expand-2 {
+  transform-origin: 0 0;
+}
+
+.height_100dvh {
+  height: 100dvh;
+}
+
+.padding_small {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+}
+
+.opacity_middle {
+  opacity: .6;
+}
+
+.margin-vertical_large {
+  margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap);
+  margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+}
+
+.display_block_tablet {
+  display: none;
+}
+
+.max-width_xlarge {
+  max-width: 60rem;
+}
+
+.width_125percent {
+  width: 125%;
+}
+
+.width_125percent.is-shift-left {
+  transform: translate(-10%);
+}
+
+.input_text-area {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-right-style: solid;
+  border-right-width: 1px;
+  border-right-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-left-style: solid;
+  border-left-width: 1px;
+  border-left-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-border);
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius);
+  background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-bg);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---input--input-primary-text);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  height: auto;
+  min-height: 7.5rem;
+  margin-bottom: 0;
+  transition: background-color .2s;
+}
+
+.custom_hero-image-left {
+  position: absolute;
+  top: 10%;
+  left: 0;
+}
+
+.width_50percent {
+  width: 50%;
+}
+
+.filter_brightness-90percent {
+  filter: brightness(90%);
+}
+
+.custom_hero-image-right {
+  justify-content: flex-end;
+  align-items: center;
+  display: flex;
+  position: absolute;
+  left: auto;
+  right: 0%;
+}
+
+.max-width_90percent {
+  max-width: 90%;
+}
+
+.flex-child_no-shrink {
+  flex: none;
+}
+
+.border_none {
+  border: 0 #0000;
+}
+
+.card_header {
+  z-index: 1;
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding) var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding) 0px;
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  justify-content: space-between;
+  align-items: stretch;
+  display: flex;
+  position: relative;
+}
+
+.custom_change-height {
+  flex-flow: column;
+  max-height: 0;
+  transition: opacity .3s, max-height .3s;
+  display: flex;
+  overflow: clip;
+}
+
+.custom_change-height.w--current {
+  color: inherit;
+  max-height: 30rem;
+  text-decoration: none;
+}
+
+.custom_hero-right-offset {
+  flex: none;
+  width: 40vw;
+  min-width: 100%;
+  max-width: 60rem;
+}
+
+.ratio_anamorphic {
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius);
+  aspect-ratio: 2.39;
+  position: relative;
+  overflow: clip;
+}
+
+.accordion_toggle-transparent {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  padding-right: 0;
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  grid-column-gap: 1rem;
+  grid-row-gap: 1rem;
+  border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius);
+  color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-color--text-primary);
+  font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size);
+  line-height: 1.2;
+  font-weight: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-weight);
+  background-color: #0000;
+  justify-content: flex-start;
+  align-items: center;
+  padding-left: 0;
+  transition: border-color .2s, background-color .2s;
+  display: flex;
+}
+
+.accordion_toggle-transparent.w--open {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.padding_xsmall {
+  padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+}
+
+.form_horizontal-wrapper {
+  grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+  align-items: stretch;
+  display: flex;
+}
+
+.padding_section {
+  padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical);
+  padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical);
+}
+
+.events_auto {
+  pointer-events: auto;
+}
+
+@media screen and (max-width: 991px) {
+  body {
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-size: .9rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight: 400;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-letter-spacing: .01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-margin-bottom: .3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font: "DM Sans", sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-size: 4.49rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-margin-bottom: .3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-size: 3.37rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-margin-bottom: .35em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-size: 1.89rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-size: 1.42rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-margin-bottom: .35em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-size: 1.2rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-size: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-letter-spacing: .1em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom: .7em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font: Manrope, sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size: 1.13rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-size: 1.4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-size: .88rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---button--button-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-size: 1.8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---tag--tag-size: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font: Manrope, sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight-bold: 600;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-line-height: 1.6rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-radius: 0px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-border-width: 3px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-letter-spacing: .01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-width: 1280px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-lg-width: 1440px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-sm-width: 1000px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-tablet\<deleted\|variable-ee5fee03-9f5f-fa94-863a-74076777e574\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-l\<deleted\|variable-24c154e3-e2bd-2abe-9e97-cc8c13b92cad\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-p\<deleted\|variable-db6b96b3-2108-c94d-520b-97f547fae1ec\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x: 1.25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical: 1em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal: 1.5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x: 2rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x: .5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x: 1.5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius: .25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x: 4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round: 100rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x: 5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x: 3rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x: 8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-tablet\<deleted\|variable-6cc22bfd-2df9-6b9d-c99e-fb5b9e0b9202\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-l\<deleted\|variable-2a022f41-6678-bea5-0011-a28ef08eeb2c\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-p\<deleted\|variable-8ffe64f7-5df6-3612-eccc-e3b77e1606d7\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x: .25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius: .5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--lg-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--xl-radius: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x: 6rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-75x: 1.75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x: 7rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---nav--nav-height: 4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  }
+
+  .container.width_100percent_tablet {
+    width: 100%;
+  }
+
+  .section {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-tablet\<deleted\|variable-ee5fee03-9f5f-fa94-863a-74076777e574\>);
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-tablet\<deleted\|variable-ee5fee03-9f5f-fa94-863a-74076777e574\>);
+  }
+
+  .grid_2-col.tablet-1-col {
+    grid-template-columns: 1fr;
+  }
+
+  .margin-top_none {
+    margin-top: 0;
+  }
+
+  .margin-bottom_none {
+    margin-bottom: 0;
+  }
+
+  .padding-bottom_none {
+    padding-bottom: 0;
+  }
+
+  .padding-top_none {
+    padding-top: 0;
+  }
+
+  .position_sticky.is-desktop-only {
+    position: static;
+  }
+
+  .position_sticky.tablet-stick-bottom {
+    top: auto;
+    bottom: 0;
+  }
+
+  .checkbox_toggle {
+    min-width: 24px;
+    min-height: 24px;
+  }
+
+  .margin-right_none {
+    margin-right: 0;
+  }
+
+  .margin-left_none {
+    margin-left: 0;
+  }
+
+  .card.tablet-unset-card {
+    border-style: none;
+  }
+
+  .card_body {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-tablet\<deleted\|variable-6cc22bfd-2df9-6b9d-c99e-fb5b9e0b9202\>);
+  }
+
+  .nav {
+    height: auto;
+  }
+
+  .nav_mobile-menu-button {
+    color: inherit;
+    background-color: #0000;
+    align-self: center;
+  }
+
+  .nav_mobile-menu-button.w--open {
+    color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-accent-color--accent-primary);
+    background-color: #0000;
+  }
+
+  .nav_mobile-menu-button.w--open:hover {
+    color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary);
+  }
+
+  .height_100percent {
+    order: -9999;
+  }
+
+  .flex_horizontal.tablet-vertical {
+    flex-flow: column;
+  }
+
+  .flex_horizontal.tablet-vertical.tablet-y-center {
+    justify-content: center;
+  }
+
+  .flex_horizontal.tablet-vertical.tablet-x-center {
+    align-items: center;
+  }
+
+  .flex_horizontal.tablet-flex-horizontal {
+    flex-flow: row;
+  }
+
+  .rotate_-12deg.tablet-straight {
+    transform: none;
+  }
+
+  .ratio_3x2_tablet {
+    aspect-ratio: 3 / 2;
+  }
+
+  .width_100percent_tablet {
+    width: 100%;
+  }
+
+  .position_relative_tablet {
+    position: relative;
+  }
+
+  .position_static_tablet {
+    position: static;
+  }
+
+  .position_absolute_tablet {
+    position: absolute;
+  }
+
+  .width_60percent_tablet {
+    width: 60%;
+  }
+
+  .height_auto_tablet {
+    height: auto;
+    min-height: auto;
+  }
+
+  .min-height_auto_tablet {
+    min-height: auto;
+  }
+
+  .width_50percent_tablet {
+    width: 50%;
+  }
+
+  .footer {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  }
+
+  .flex_vertical.gap-large {
+    justify-content: flex-end;
+    align-items: stretch;
+  }
+
+  .nav_link {
+    font-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size);
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .nav_link:hover {
+    color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---text-link--link-primary);
+    background-color: color-mix(in srgb, currentColor 0%, transparent);
+  }
+
+  .nav_link.w--current:hover {
+    background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---button--button-secondary-bg-hover);
+  }
+
+  .nav_link.w--open {
+    background-color: #0000;
+  }
+
+  .sg_table-row {
+    flex-flow: column;
+  }
+
+  .sg_table-row.sg_table-head {
+    display: none;
+  }
+
+  .sg_table-row.sg_border-bottom {
+    grid-column-gap: 1rem;
+    grid-row-gap: 1rem;
+    flex-flow: column;
+  }
+
+  .sg_table-row.sg_gap {
+    flex-flow: column;
+  }
+
+  .sg_table-cell-title {
+    width: auto;
+  }
+
+  .sg_table-cell {
+    justify-content: flex-start;
+    align-items: flex-start;
+  }
+
+  .sg_color-sample {
+    aspect-ratio: auto;
+    align-self: stretch;
+  }
+
+  .sg_table-col {
+    flex-basis: 15rem;
+  }
+
+  .nav_menu-full-screen {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    overflow: auto;
+  }
+
+  .sg_colors-column {
+    flex-flow: column;
+  }
+
+  .ratio_1x1_tablet {
+    aspect-ratio: 1;
+  }
+
+  .card_body_small {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-tablet\<deleted\|variable-6cc22bfd-2df9-6b9d-c99e-fb5b9e0b9202\>);
+  }
+
+  .padding-horizontal_none, .padding-vertical_none {
+    padding: 0;
+  }
+
+  .sg_grid {
+    grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
+  }
+
+  .sg_grid-buttons {
+    grid-template-rows: auto auto;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .grid_3-col.tablet-1-col {
+    grid-template-columns: 1fr;
+  }
+
+  .grid_9-col, .grid_6-col {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr;
+  }
+
+  .grid_6-col.tablet-1-col {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .grid_5-col {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr;
+  }
+
+  .grid_5-col.tablet-1-col {
+    grid-template-columns: 1fr;
+  }
+
+  .grid_4-col {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .grid_4-col.tablet-1-col {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .grid_12-col {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr 1fr 1fr;
+  }
+
+  .grid_8-col {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 1fr 1fr;
+  }
+
+  .tabs_nav {
+    flex-flow: wrap;
+  }
+
+  .nav_menu {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    padding-right: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    padding-left: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    border-top-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius);
+    border-top-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius);
+    border-bottom-left-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius);
+    border-bottom-right-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius);
+    background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---background-color--bg-primary);
+    height: auto;
+    max-height: calc(100dvh - 10rem);
+    position: absolute;
+    top: 100%;
+    overflow: auto;
+    box-shadow: 0 4px 8px #0000001a;
+  }
+
+  .nav_menu-list {
+    flex-flow: column;
+  }
+
+  .nav_menu-list-item {
+    flex-flow: column;
+    margin-bottom: 0;
+  }
+
+  .nav_dropdown-menu {
+    width: 100%;
+    height: auto;
+  }
+
+  .mega-nav_dropdown-list.w--open {
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+    height: auto;
+    position: relative;
+    top: 0%;
+  }
+
+  .mega-nav_dropdown-list-wrapper {
+    z-index: 3;
+    box-shadow: none;
+    background-color: color-mix(in srgb, currentColor 5%, transparent);
+    padding: 1rem;
+  }
+
+  .mega-nav_dropdown-list-wrapper.w--open {
+    flex-flow: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    min-width: 0;
+    height: auto;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 1rem;
+    position: relative;
+    top: auto;
+    left: 0;
+    right: 0;
+  }
+
+  .padding_none {
+    padding: 0;
+  }
+
+  .hide_tablet {
+    display: none;
+  }
+
+  .margin_none {
+    margin: 0;
+  }
+
+  .max-height_100vh_desktop {
+    max-height: none;
+  }
+
+  .ratio_3x2_tablet-1 {
+    aspect-ratio: 3 / 2;
+  }
+
+  .display_block_tablet {
+    display: block;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  body {
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-size: .8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight: 400;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-letter-spacing: .01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font: "DM Sans", sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-size: 3.59rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-size: 2.69rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-size: 1.52rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-size: 1.14rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-size: 1.08rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-size: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-letter-spacing: .1em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom: .7em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font: Manrope, sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size: 1.1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-size: 1.3rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-size: .88rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---button--button-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-size: 1.6rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---tag--tag-size: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font: Manrope, sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight-bold: 600;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-line-height: 1.6rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-radius: 0px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-border-width: 3px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-size: .8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-letter-spacing: .01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-width: 1280px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-lg-width: 1440px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-sm-width: 1000px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-tablet\<deleted\|variable-ee5fee03-9f5f-fa94-863a-74076777e574\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-l\<deleted\|variable-24c154e3-e2bd-2abe-9e97-cc8c13b92cad\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-p\<deleted\|variable-db6b96b3-2108-c94d-520b-97f547fae1ec\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x: 1.25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical: 1em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal: 1.5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x: 2rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x: .5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x: 1.5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius: .25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x: 4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round: 100rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x: 5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x: 3rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x: 8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-tablet\<deleted\|variable-6cc22bfd-2df9-6b9d-c99e-fb5b9e0b9202\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-l\<deleted\|variable-2a022f41-6678-bea5-0011-a28ef08eeb2c\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-p\<deleted\|variable-8ffe64f7-5df6-3612-eccc-e3b77e1606d7\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x: .25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius: .5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--lg-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--xl-radius: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x: 6rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-75x: 1.75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x: 7rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---nav--nav-height: 4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  }
+
+  .section {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-l\<deleted\|variable-24c154e3-e2bd-2abe-9e97-cc8c13b92cad\>);
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-l\<deleted\|variable-24c154e3-e2bd-2abe-9e97-cc8c13b92cad\>);
+  }
+
+  .grid_2-col {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .grid_2-col.gap-small {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  }
+
+  .grid_2-col.gap-medium {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  }
+
+  .grid_2-col.mobile-l-1-col {
+    grid-template-columns: 1fr;
+  }
+
+  .grid_2-col.gap-xxlarge, .grid_2-col.gap-large {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  }
+
+  .margin-top_none {
+    margin-top: 0;
+  }
+
+  .margin-bottom_none {
+    margin-bottom: 0;
+  }
+
+  .padding-bottom_none {
+    padding-bottom: 0;
+  }
+
+  .padding-top_none {
+    padding-top: 0;
+  }
+
+  .padding-bottom_small {
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  }
+
+  .padding-top_small {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  }
+
+  .position_sticky.mobile-relative {
+    position: sticky;
+  }
+
+  .margin-right_none {
+    margin-right: 0;
+  }
+
+  .margin-left_none {
+    margin-left: 0;
+  }
+
+  .margin-top_small {
+    margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  }
+
+  .margin-top_large {
+    margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .margin-top_large.mobile-landscape-0 {
+    margin-top: 0;
+  }
+
+  .margin-top_medium {
+    margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  }
+
+  .margin-bottom_small {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  }
+
+  .margin-bottom_medium {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  }
+
+  .margin-bottom_large {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .padding-bottom_medium {
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  }
+
+  .padding-bottom_large {
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .padding-top_medium {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  }
+
+  .padding-top_large {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .rich-text blockquote {
+    font-size: 1.5rem;
+  }
+
+  .card.ix_sticky-height-expand-wrapper {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+    height: auto;
+  }
+
+  .margin-top_xxlarge {
+    margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  }
+
+  .margin-bottom_xxlarge {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  }
+
+  .card_body {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-l\<deleted\|variable-2a022f41-6678-bea5-0011-a28ef08eeb2c\>);
+  }
+
+  .slider_arrow {
+    height: 40px;
+    inset: 0%;
+  }
+
+  .slider_arrow.is-next {
+    inset: auto 0% 0% auto;
+  }
+
+  .slider_arrow.is-previous {
+    inset: auto auto 0% 0%;
+  }
+
+  .flex_horizontal.gap-large {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .flex_horizontal.flex_vertical_mobile-l {
+    flex-flow: column;
+  }
+
+  .flex_horizontal.mobile-horizontal {
+    flex-flow: row;
+  }
+
+  .flex_horizontal.mobile-l-vertical {
+    flex-flow: column;
+  }
+
+  .padding_large {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+  }
+
+  .display_none_mobile-l {
+    display: none;
+  }
+
+  .padding-bottom_xxlarge {
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .padding-top_xxlarge {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  }
+
+  .width_70percent_mobile-l {
+    width: 70%;
+  }
+
+  .width_80percent_mobile-l {
+    width: 80%;
+  }
+
+  .ratio_auto_mobile-l {
+    aspect-ratio: auto;
+  }
+
+  .max-width_small {
+    max-width: 100%;
+  }
+
+  .margin-top_xlarge {
+    margin-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  }
+
+  .margin-bottom_xlarge {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+  }
+
+  .padding-bottom_xlarge {
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .padding-top_xlarge {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .text-align_center_mobile-l {
+    text-align: center;
+  }
+
+  .flex_vertical.gap-large {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .sg_logo {
+    height: auto;
+    padding-top: 20px;
+    padding-left: 20px;
+    padding-right: 20px;
+    position: static;
+  }
+
+  .sg_nav-menu {
+    justify-content: flex-start;
+    height: 60px;
+    margin-left: 0;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+
+  .width_100percent_mobile-l {
+    width: 100%;
+  }
+
+  .hide_mobile-l {
+    display: none;
+  }
+
+  .ix_card-change-width {
+    margin-bottom: 1rem;
+    margin-right: 0;
+  }
+
+  .ix_card-change-width-background.is-mobile-card {
+    width: 100%;
+    height: 100%;
+  }
+
+  .dropdown_toggle {
+    justify-content: center;
+    align-items: center;
+  }
+
+  .card_body_small {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-l\<deleted\|variable-2a022f41-6678-bea5-0011-a28ef08eeb2c\>);
+  }
+
+  .padding-horizontal_none, .padding-vertical_none {
+    padding: 0;
+  }
+
+  .grid_3-col {
+    grid-template-columns: 1fr;
+  }
+
+  .grid_9-col, .grid_6-col, .grid_5-col {
+    grid-template-columns: minmax(0, 1fr) 1fr;
+  }
+
+  .grid_5-col.gap-small {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  }
+
+  .grid_5-col.gap-medium {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  }
+
+  .grid_4-col {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .grid_1-col.gap-medium {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap);
+  }
+
+  .grid_1-col.gap-small {
+    grid-column-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+    grid-row-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+  }
+
+  .grid_12-col, .grid_8-col {
+    grid-template-columns: minmax(0, 1fr) 1fr;
+  }
+
+  .tabs_nav, .tabs_nav.is-bottom {
+    flex-flow: column;
+    justify-content: flex-start;
+    align-items: stretch;
+  }
+
+  .padding_none {
+    padding: 0;
+  }
+
+  .header.is-2-col {
+    grid-column-gap: 0rem;
+    grid-row-gap: 0rem;
+    display: flex;
+  }
+
+  .header {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .footer_bottom {
+    text-align: center;
+    flex-flow: column;
+  }
+
+  .position_sticky-bottom {
+    position: relative;
+  }
+
+  .padding_small {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+  }
+
+  .height_auto_mobile-l {
+    height: auto;
+    min-height: auto;
+  }
+
+  .margin-vertical_large {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+  }
+
+  .margin-top_0_mobile-l {
+    margin-top: 0;
+  }
+}
+
+@media screen and (max-width: 479px) {
+  body {
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-size: .8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight: 400;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---eyebrow--eyebrow-letter-spacing: .01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-margin-bottom: .3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--heading-font: "DM Sans", sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-size: 2.87rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-line-height: 1.2em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h0-heading--h0-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-margin-bottom: .3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-size: 2.15rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h1-heading--h1-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-margin-bottom: .35em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-size: 1.21rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h2-heading--h2-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-size: .91rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-line-height: 1.04em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h3-heading--h3-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-margin-bottom: .35em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-size: .97rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h4-heading--h4-letter-spacing: -.01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h5-heading--h5-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-margin-bottom: .5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-size: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-weight: 500;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---h6-heading--h6-letter-spacing: .1em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-margin-bottom: .7em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font: Manrope, sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-size: 1.1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-lg--lg-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-size: 1.2rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xl--xl-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-size: .88rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-sm--sm-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---button--button-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-size: 1.4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text-xxl--xxl-text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---tag--tag-size: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-size: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--button-font: Manrope, sans-serif;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-weight-bold: 600;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-line-height: 1.6rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-letter-spacing: 0em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---text--text-line-height: 1.6em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-radius: 0px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-border-width: 3px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-font: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---font--body-font);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-size: .8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-letter-spacing: .01em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-line-height: 1.3em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---blockquote--blockquote-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-width: 1280px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-lg-width: 1440px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---container--container-sm-width: 1000px;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-tablet\<deleted\|variable-ee5fee03-9f5f-fa94-863a-74076777e574\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-l\<deleted\|variable-24c154e3-e2bd-2abe-9e97-cc8c13b92cad\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-p\<deleted\|variable-db6b96b3-2108-c94d-520b-97f547fae1ec\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-25x: 1.25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--sm-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--md-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--lg-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-vertical: 1em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-padding-horizontal: 1.5em;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-75x: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---input--input-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1x: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x: 2rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x: .5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x: 1.5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--sm-radius: .25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--4x: 4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--round: 100rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x: 5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x: 3rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---image--image-radius: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-radius);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--8x: 8rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--3x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-tablet\<deleted\|variable-6cc22bfd-2df9-6b9d-c99e-fb5b9e0b9202\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--2x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-l\<deleted\|variable-2a022f41-6678-bea5-0011-a28ef08eeb2c\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-p\<deleted\|variable-8ffe64f7-5df6-3612-eccc-e3b77e1606d7\>: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xxs-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x: .25rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-horizontal: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--md-radius: .5rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--lg-radius: .75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---radius--xl-radius: 1rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--6x: 6rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xl-gap: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--5x);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--1-75x: 1.75rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--7x: 7rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---button--button-size: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_typography---base-typography--base-font-size);
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---nav--nav-height: 4rem;
+    --ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---tag--tag-padding-vertical: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---spacing--0-25x);
+  }
+
+  .section {
+    padding-top: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-p\<deleted\|variable-db6b96b3-2108-c94d-520b-97f547fae1ec\>);
+    padding-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---section--section-padding-vertical-mobile-p\<deleted\|variable-db6b96b3-2108-c94d-520b-97f547fae1ec\>);
+  }
+
+  .button {
+    white-space: nowrap;
+  }
+
+  .input_field.is-select {
+    background-position: 96%;
+  }
+
+  .margin-top_none {
+    margin-top: 0;
+  }
+
+  .margin-bottom_none {
+    margin-bottom: 0;
+  }
+
+  .padding-bottom_none {
+    padding-bottom: 0;
+  }
+
+  .padding-top_none {
+    padding-top: 0;
+  }
+
+  .position_sticky.mobile-relative {
+    position: relative;
+  }
+
+  .avatar {
+    margin-bottom: 16px;
+  }
+
+  .margin-right_none {
+    margin-right: 0;
+  }
+
+  .margin-left_none {
+    margin-left: 0;
+  }
+
+  .button-group {
+    flex-flow: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    width: 100%;
+  }
+
+  .card.ix_sticky-height-expand-wrapper {
+    margin-bottom: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---gap--xs-gap);
+    height: auto;
+    min-height: auto;
+  }
+
+  .card_body {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-p\<deleted\|variable-8ffe64f7-5df6-3612-eccc-e3b77e1606d7\>);
+  }
+
+  .nav_mobile-menu-button.w--open {
+    color: inherit;
+  }
+
+  .text-align_center_mobile {
+    text-align: center;
+  }
+
+  .is-select {
+    background-position: 96%;
+  }
+
+  .width_100percent_mobile {
+    width: 100%;
+  }
+
+  .logo {
+    color: inherit;
+  }
+
+  .heading-responsive_large {
+    font-size: 12cqw;
+    line-height: 1.2;
+  }
+
+  .sg_logo.w--current {
+    align-items: center;
+  }
+
+  .nav_menu-full-screen {
+    padding: 0;
+  }
+
+  .card_body_small {
+    padding: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308_sizes---card--card-padding-mobile-p\<deleted\|variable-8ffe64f7-5df6-3612-eccc-e3b77e1606d7\>);
+  }
+
+  .padding-horizontal_none, .padding-vertical_none {
+    padding: 0;
+  }
+
+  .grid_9-col, .grid_6-col, .grid_5-col, .grid_12-col, .grid_8-col {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .padding_none {
+    padding: 0;
+  }
+
+  .footer_icon-group {
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
+  .margin_none {
+    margin: 0;
+  }
+
+  .position_sticky-bottom {
+    position: relative;
+  }
+
+  .form_horizontal-wrapper {
+    flex-direction: column;
+  }
+}
+
+#w-node-_83130efd-cc89-3e63-e012-238651cb9c90-51cb9c8e.w-node-_74183d39-97ba-696d-d9e0-d3e4e5d79529-055fd1ce {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_83130efd-cc89-3e63-e012-238651cb9c93-51cb9c8e.w-node-_74183d39-97ba-696d-d9e0-d3e4e5d79533-055fd1ce {
+  grid-area: 1 / 1 / 2 / 2;
+  align-self: end;
+}
+
+#w-node-b44b49b5-d3e6-a05f-997e-8ac7efbac3da-51cb9c8e.w-node-_74183d39-97ba-696d-d9e0-d3e4e5d79531-055fd1ce {
+  align-self: end;
+}
+
+#w-node-c566b793-7ed4-f098-3301-ccfdd3a617bc-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d54-055fd1ce {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+}
+
+#w-node-c566b793-7ed4-f098-3301-ccfdd3a617bd-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d2d-055fd1ce {
+  grid-area: 1 / 1 / 2 / 5;
+}
+
+#w-node-c566b793-7ed4-f098-3301-ccfdd3a617c1-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d28-055fd1ce, #w-node-c566b793-7ed4-f098-3301-ccfdd3a617c7-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d19-055fd1ce, #w-node-_9bf402c4-a9d1-a662-f2a4-08af26ba9ae4-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d23-055fd1ce {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+}
+
+#w-node-c566b793-7ed4-f098-3301-ccfdd3a617d9-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d4a-055fd1ce {
+  grid-area: 2 / 1 / 3 / 5;
+}
+
+#w-node-e1d6f978-b400-4ad5-acf8-8869285ac4d3-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d47-055fd1ce, #w-node-_32b61d4c-dce5-52fe-303b-c98d654052ca-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d39-055fd1ce, #w-node-_32b61d4c-dce5-52fe-303b-c98d654052d0-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d43-055fd1ce {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+}
+
+#w-node-c566b793-7ed4-f098-3301-ccfdd3a617f5-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d53-055fd1ce {
+  grid-area: 1 / 5 / 3 / 7;
+}
+
+#w-node-_25aa69ea-f6ff-a983-3b30-a346b1836f6c-7ac2c669.w-node-bd678469-22c4-f2df-4448-11fb241a1843-055fd1ce {
+  grid-area: 1 / 2 / 2 / 5;
+}
+
+#w-node-cbbfa81d-641d-6741-5de9-6b9e7ac2c66d-7ac2c669.w-node-bd678469-22c4-f2df-4448-11fb241a184f-055fd1ce {
+  grid-area: 1 / 1 / 2 / 5;
+  place-self: end start;
+}
+
+#w-node-_0dc7589f-614c-e2cf-7555-5eed0be05d1f-0be05d1c.w-node-f5984468-b07a-271c-06a7-f4645ab0ffb7-055fd1ce {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+}
+
+#w-node-d6288141-3e37-a760-1f1f-3f87c261e1bc-0be05d1c.w-node-f5984468-b07a-271c-06a7-f4645ab0ffc6-055fd1ce, #w-node-_57b0b48d-fc7d-2a70-7d13-21713b2c2f03-0be05d1c.w-node-f5984468-b07a-271c-06a7-f4645ab0ffe4-055fd1ce {
+  grid-area: span 2 / span 1 / span 2 / span 1;
+}
+
+#w-node-_05e54f8c-7d0c-01e1-5321-d818b7d69662-5ebb016a.w-node-_851fc987-fbf0-69dc-8fc4-d770671b8b0d-055fd1ce, #w-node-_05e54f8c-7d0c-01e1-5321-d818b7d69664-5ebb016a.w-node-_851fc987-fbf0-69dc-8fc4-d770671b8b2e-055fd1ce {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_86672d52-e14b-c232-ad3a-e062de5187ae-5ebb016a.w-node-_851fc987-fbf0-69dc-8fc4-d770671b8b28-055fd1ce {
+  grid-area: span 1 / span 2 / span 1 / span 2;
+  align-self: center;
+}
+
+#w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280.w-node-e5c63cf8-d464-4b5c-779f-87db4b792fc8-055fd1ce {
+  grid-area: 1 / 2 / 2 / 5;
+}
+
+#w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280.w-node-e5c63cf8-d464-4b5c-779f-87db4b792ff1-055fd1ce {
+  grid-area: 2 / 2 / 3 / 5;
+}
+
+#w-node-_851d61a1-1dad-400a-5b6a-92b99f998536-b17c3d94.w-node-_8489c8c1-07dc-6ab4-cde4-f5c814a2d0ce-14a2d0cb, #w-node-_61be48fd-08da-7879-1198-67c4146a0181-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc673e-93dc6729 {
+  grid-area: span 1 / span 2 / span 1 / span 2;
+}
+
+#w-node-_61be48fd-08da-7879-1198-67c4146a018c-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc6749-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a0197-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc6754-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a01a2-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc675f-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a01b1-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc676e-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a01bc-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc6779-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a01c7-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc6784-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a01d6-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc6793-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a01e1-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc679e-93dc6729, #w-node-_61be48fd-08da-7879-1198-67c4146a01ec-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc67a9-93dc6729 {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+}
+
+#w-node-_61be48fd-08da-7879-1198-67c4146a01f2-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc67af-93dc6729 {
+  align-self: stretch;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e5b6e-055fd1d7 {
+  justify-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e5b7c-055fd1d7 {
+  align-self: end;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e5d77-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e5dc4-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e5e3f-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e5e8f-055fd1d7 {
+  align-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e5e9f-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e5ea1-055fd1d7 {
+  justify-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e61ea-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e61f1-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e61f3-055fd1d7 {
+  grid-area: 2 / 1 / 3 / 2;
+  justify-self: end;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e61f5-055fd1d7 {
+  grid-area: 2 / 1 / 3 / 2;
+  justify-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e61fb-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6202-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6204-055fd1d7 {
+  grid-area: 2 / 1 / 3 / 2;
+  justify-self: end;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6206-055fd1d7 {
+  grid-area: 2 / 1 / 3 / 2;
+  justify-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e627a-055fd1d7 {
+  justify-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6530-055fd1d7 {
+  grid-area: 1 / 2 / 2 / 3;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6531-055fd1d7 {
+  grid-area: 1 / 9 / 2 / 10;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6532-055fd1d7 {
+  grid-area: 3 / 6 / 4 / 7;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6533-055fd1d7 {
+  grid-area: 5 / 4 / 6 / 5;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6534-055fd1d7 {
+  grid-area: 5 / 10 / 6 / 11;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e653b-055fd1d7 {
+  justify-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e653d-055fd1d7 {
+  grid-area: span 1 / span 2 / span 1 / span 2;
+  align-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e653e-055fd1d7 {
+  align-self: end;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e653f-055fd1d7 {
+  align-self: stretch;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6544-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6547-055fd1d7 {
+  grid-area: 3 / 1 / 4 / 3;
+  justify-self: start;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e654b-055fd1d7 {
+  grid-area: 1 / 2 / 2 / 4;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e654c-055fd1d7 {
+  grid-area: 1 / 9 / 2 / 11;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e654d-055fd1d7 {
+  grid-area: 3 / 6 / 4 / 8;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e654e-055fd1d7 {
+  grid-area: 5 / 3 / 6 / 5;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e654f-055fd1d7 {
+  grid-area: 5 / 10 / 6 / 12;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6554-055fd1d7 {
+  grid-area: 1 / 1 / 4 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6555-055fd1d7 {
+  grid-area: 4 / 1 / 6 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6556-055fd1d7 {
+  grid-area: 1 / 2 / 6 / 3;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e655a-055fd1d7 {
+  grid-area: 1 / 2 / 2 / 3;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e655b-055fd1d7 {
+  grid-area: 1 / 9 / 2 / 10;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e655c-055fd1d7 {
+  grid-area: 3 / 6 / 4 / 7;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e655d-055fd1d7 {
+  grid-area: 5 / 4 / 6 / 5;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e655e-055fd1d7 {
+  grid-area: 5 / 10 / 6 / 11;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6565-055fd1d7 {
+  grid-area: 2 / 2 / 3 / 3;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6566-055fd1d7 {
+  grid-area: 3 / 3 / 4 / 7;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6567-055fd1d7 {
+  grid-area: 4 / 6 / 5 / 8;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6568-055fd1d7 {
+  grid-area: 6 / 5 / 7 / 6;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e656b-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e656c-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6570-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6571-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6572-055fd1d7 {
+  grid-area: 2 / 1 / 3 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6573-055fd1d7 {
+  grid-area: 3 / 1 / 4 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6574-055fd1d7 {
+  grid-area: 1 / 1 / 5 / 2;
+  place-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e657d-055fd1d7 {
+  align-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6584-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6585-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+  place-self: stretch stretch;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6592-055fd1d7 {
+  order: 0;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e6594-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e659b-055fd1d7 {
+  grid-area: 1 / 1 / 2 / 2;
+  place-self: center;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a1-055fd1d7 {
+  grid-area: 1 / 1 / 5 / 5;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a2-055fd1d7 {
+  grid-area: 2 / 4 / 6 / 7;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a3-055fd1d7 {
+  grid-area: 3 / 2 / 7 / 5;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a4-055fd1d7 {
+  grid-area: 4 / 3 / 8 / 6;
+}
+
+#w-node-_6401b070-0ac8-bcf0-2647-73725f5e65b2-055fd1d7 {
+  align-self: center;
+}
+
+#w-node-_857eff80-a064-80f6-efa6-2aa55402b17a-5402b172.w-node-aca1decb-952a-6d03-8948-04348d12084d-0653ac4e {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+  align-self: center;
+}
+
+#w-node-_69eef483-595b-b8a4-c55f-fae117023768-fac197f7.w-node-_8b7dc65c-6ccd-ef76-b980-6f80d8a3b838-0653ac4e {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+}
+
+#w-node-_026bb609-41ff-e8dc-7098-9278fac19805-fac197f7.w-node-_8b7dc65c-6ccd-ef76-b980-6f80d8a3b84c-0653ac4e {
+  grid-area: span 1 / span 2 / span 1 / span 2;
+}
+
+#w-node-b615decb-87c9-b3e5-f4d8-6892b2e7a2b8-b2e7a2ac.w-node-eaa6f51b-ba16-9fc0-4e7a-fb6437f07068-869f6535 {
+  grid-area: 1 / 1 / 2 / 3;
+}
+
+#w-node-b615decb-87c9-b3e5-f4d8-6892b2e7a2bb-b2e7a2ac.w-node-eaa6f51b-ba16-9fc0-4e7a-fb6437f07064-869f6535 {
+  grid-area: 1 / 3 / 3 / 6;
+}
+
+#w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280.w-node-ac52873d-5748-0aed-3d44-55d4506b6066-d19277d5 {
+  grid-area: 1 / 2 / 2 / 5;
+}
+
+#w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280.w-node-ac52873d-5748-0aed-3d44-55d4506b609d-d19277d5 {
+  grid-area: 2 / 2 / 3 / 5;
+}
+
+#w-node-ef1a1ac3-2775-0c24-b701-9034ee5207a3-ee5207a0.w-node-_8aa97011-c8af-3148-cf29-a44abcba7af6-d19277d5 {
+  grid-area: span 1 / span 2 / span 1 / span 2;
+}
+
+#w-node-ef1a1ac3-2775-0c24-b701-9034ee5207a5-ee5207a0.w-node-_8aa97011-c8af-3148-cf29-a44abcba7aff-d19277d5 {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+  align-self: end;
+}
+
+#w-node-_54aa7a73-9cec-1e95-d1b2-f0cc4cd7feab-b1f84ccf.w-node-e5bc7b60-f4e5-2026-adc4-34e1d311b11c-df7276e1 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_25f8541a-af87-b3be-dfd7-8e4c62557276-b1f84ccf.w-node-e5bc7b60-f4e5-2026-adc4-34e1d311b11e-df7276e1 {
+  grid-area: 1 / 2 / 2 / 4;
+  align-self: stretch;
+}
+
+#w-node-_2ef895df-c773-26eb-4339-f405e0068865-b1f84ccf.w-node-e5bc7b60-f4e5-2026-adc4-34e1d311b120-df7276e1 {
+  grid-area: 1 / 4 / 2 / 5;
+}
+
+#w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc0e-ad47cc0a.w-node-a2e67149-e019-c139-b51a-6fbcbc9be87b-df7276e1 {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+  align-self: start;
+}
+
+#w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc18-ad47cc0a.w-node-a2e67149-e019-c139-b51a-6fbcbc9be8b4-df7276e1 {
+  align-self: start;
+}
+
+#w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc1b-ad47cc0a.w-node-a2e67149-e019-c139-b51a-6fbcbc9be87c-df7276e1, #w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc29-ad47cc0a.w-node-a2e67149-e019-c139-b51a-6fbcbc9be88a-df7276e1, #w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc37-ad47cc0a.w-node-a2e67149-e019-c139-b51a-6fbcbc9be898-df7276e1, #w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc45-ad47cc0a.w-node-a2e67149-e019-c139-b51a-6fbcbc9be8a6-df7276e1 {
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+#w-node-_0dc7589f-614c-e2cf-7555-5eed0be05d1f-0be05d1c.w-node-_634be294-27c0-98aa-065d-1bda5753a2e2-df7276e1 {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+}
+
+#w-node-d6288141-3e37-a760-1f1f-3f87c261e1bc-0be05d1c.w-node-_634be294-27c0-98aa-065d-1bda5753a2f1-df7276e1, #w-node-_57b0b48d-fc7d-2a70-7d13-21713b2c2f03-0be05d1c.w-node-_634be294-27c0-98aa-065d-1bda5753a30d-df7276e1 {
+  grid-area: span 2 / span 1 / span 2 / span 1;
+}
+
+#w-node-a0716485-74b7-5610-0f39-21a551ba8ab3-51ba8aae.w-node-_8f7bd1a1-5c28-01fc-fedd-74dceca3d3cb-df7276e1 {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+  place-self: center end;
+}
+
+#w-node-_2eb957ac-a779-b7e8-c895-939eedaeea12-edaeea0f.w-node-f1b26e5a-b33b-e9ba-a521-149172f27d26-6cecf403 {
+  grid-area: span 1 / span 1 / span 1 / span 1;
+  align-self: center;
+}
+
+#w-node-_2eb957ac-a779-b7e8-c895-939eedaeea1f-edaeea0f.w-node-f1b26e5a-b33b-e9ba-a521-149172f27d28-6cecf403 {
+  grid-area: 1 / 2 / 6 / 10;
+}
+
+#w-node-_2eb957ac-a779-b7e8-c895-939eedaeea21-edaeea0f.w-node-f1b26e5a-b33b-e9ba-a521-149172f27d2a-6cecf403 {
+  grid-area: 2 / 1 / 7 / 9;
+  align-self: center;
+}
+
+#w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280.w-node-_7832ce19-a422-a702-f7e2-3da1dc2330d2-6cecf403 {
+  grid-area: 1 / 2 / 2 / 5;
+}
+
+#w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280.w-node-_7832ce19-a422-a702-f7e2-3da1dc2330fb-6cecf403 {
+  grid-area: 2 / 2 / 3 / 5;
+}
+
+@media screen and (max-width: 991px) {
+  #w-node-_83130efd-cc89-3e63-e012-238651cb9c93-51cb9c8e.w-node-_74183d39-97ba-696d-d9e0-d3e4e5d79533-055fd1ce {
+    align-self: end;
+  }
+
+  #w-node-c566b793-7ed4-f098-3301-ccfdd3a617bd-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d2d-055fd1ce, #w-node-c566b793-7ed4-f098-3301-ccfdd3a617d9-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d4a-055fd1ce {
+    grid-area: span 1 / span 2 / span 1 / span 2;
+  }
+
+  #w-node-c566b793-7ed4-f098-3301-ccfdd3a617f5-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d53-055fd1ce {
+    grid-area: span 2 / span 2 / span 2 / span 2;
+  }
+
+  #w-node-_25aa69ea-f6ff-a983-3b30-a346b1836f6c-7ac2c669.w-node-bd678469-22c4-f2df-4448-11fb241a1843-055fd1ce {
+    grid-row: 2 / 3;
+    grid-column-start: 1;
+  }
+
+  #w-node-cbbfa81d-641d-6741-5de9-6b9e7ac2c66d-7ac2c669.w-node-bd678469-22c4-f2df-4448-11fb241a184f-055fd1ce {
+    grid-column-end: 5;
+  }
+
+  #w-node-_86672d52-e14b-c232-ad3a-e062de5187ae-5ebb016a.w-node-_851fc987-fbf0-69dc-8fc4-d770671b8b28-055fd1ce {
+    order: -9999;
+    grid-column: span 1 / span 1;
+  }
+
+  #w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280.w-node-e5c63cf8-d464-4b5c-779f-87db4b792fc8-055fd1ce, #w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280.w-node-e5c63cf8-d464-4b5c-779f-87db4b792ff1-055fd1ce {
+    grid-column: 1 / 6;
+  }
+
+  #w-node-_61be48fd-08da-7879-1198-67c4146a01f2-d66a6ef8.w-node-_41e4cb1a-a620-245f-7f74-dc8693dc67af-93dc6729 {
+    grid-area: span 1 / span 2 / span 1 / span 2;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e653e-055fd1d7 {
+    grid-area: 1 / 1 / 2 / 5;
+    align-self: center;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e653f-055fd1d7 {
+    grid-area: 1 / 4 / 2 / 8;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6554-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6555-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6556-055fd1d7 {
+    grid-area: span 1 / span 1 / span 1 / span 1;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6565-055fd1d7 {
+    grid-column-end: 4;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6567-055fd1d7 {
+    grid-column-end: 9;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6568-055fd1d7 {
+    grid-column-end: 7;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a4-055fd1d7 {
+    grid-column-end: 5;
+  }
+
+  #w-node-_857eff80-a064-80f6-efa6-2aa55402b17a-5402b172.w-node-aca1decb-952a-6d03-8948-04348d12084d-0653ac4e {
+    order: -9999;
+  }
+
+  #w-node-b615decb-87c9-b3e5-f4d8-6892b2e7a2b8-b2e7a2ac.w-node-eaa6f51b-ba16-9fc0-4e7a-fb6437f07068-869f6535, #w-node-b615decb-87c9-b3e5-f4d8-6892b2e7a2bb-b2e7a2ac.w-node-eaa6f51b-ba16-9fc0-4e7a-fb6437f07064-869f6535 {
+    grid-area: span 1 / span 2 / span 1 / span 2;
+  }
+
+  #w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280.w-node-ac52873d-5748-0aed-3d44-55d4506b6066-d19277d5, #w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280.w-node-ac52873d-5748-0aed-3d44-55d4506b609d-d19277d5 {
+    grid-column: 1 / 6;
+  }
+
+  #w-node-ef1a1ac3-2775-0c24-b701-9034ee5207a3-ee5207a0.w-node-_8aa97011-c8af-3148-cf29-a44abcba7af6-d19277d5, #w-node-ef1a1ac3-2775-0c24-b701-9034ee5207a5-ee5207a0.w-node-_8aa97011-c8af-3148-cf29-a44abcba7aff-d19277d5 {
+    grid-column: span 3 / span 3;
+  }
+
+  #w-node-_9e47ebc7-0308-5a40-0847-0a8cb1f84cd9-b1f84ccf.w-node-e5bc7b60-f4e5-2026-adc4-34e1d311b12b-df7276e1, #w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc0f-ad47cc0a.w-node-a2e67149-e019-c139-b51a-6fbcbc9be87a-df7276e1, #IX-custom-height-1.w-node-a2e67149-e019-c139-b51a-6fbcbc9be873-df7276e1, #IX-custom-height-2.w-node-a2e67149-e019-c139-b51a-6fbcbc9be875-df7276e1, #IX-custom-height-3.w-node-a2e67149-e019-c139-b51a-6fbcbc9be877-df7276e1, #IX-custom-height-4.w-node-a2e67149-e019-c139-b51a-6fbcbc9be879-df7276e1 {
+    order: -9999;
+  }
+
+  #w-node-a0716485-74b7-5610-0f39-21a551ba8ab3-51ba8aae.w-node-_8f7bd1a1-5c28-01fc-fedd-74dceca3d3cb-df7276e1 {
+    justify-self: start;
+  }
+
+  #w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280.w-node-_7832ce19-a422-a702-f7e2-3da1dc2330d2-6cecf403, #w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280.w-node-_7832ce19-a422-a702-f7e2-3da1dc2330fb-6cecf403 {
+    grid-column: 1 / 6;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  #w-node-c566b793-7ed4-f098-3301-ccfdd3a617f5-d3a617ba.w-node-_1a6e1d88-5744-48ea-d198-9a7dc9601d53-055fd1ce {
+    grid-column: span 2 / span 2;
+  }
+
+  #w-node-_851d61a1-1dad-400a-5b6a-92b99f998536-b17c3d94.w-node-_8489c8c1-07dc-6ab4-cde4-f5c814a2d0ce-14a2d0cb {
+    grid-area: span 1 / span 2 / span 1 / span 2;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6530-055fd1d7 {
+    grid-column-start: 1;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6531-055fd1d7 {
+    grid-column-end: 11;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6532-055fd1d7 {
+    grid-column-start: 5;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6533-055fd1d7 {
+    grid-column-end: 6;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6534-055fd1d7 {
+    grid-column-end: 12;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e654b-055fd1d7 {
+    grid-column: 1 / 4;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e654c-055fd1d7 {
+    grid-column: 8 / 11;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e654d-055fd1d7 {
+    grid-column-end: 9;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e654e-055fd1d7 {
+    grid-column-start: 2;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e654f-055fd1d7 {
+    grid-column-end: 13;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655a-055fd1d7 {
+    grid-column-start: 1;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655b-055fd1d7 {
+    grid-column-end: 11;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655c-055fd1d7 {
+    grid-column-start: 5;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655d-055fd1d7 {
+    grid-column-end: 6;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655e-055fd1d7 {
+    grid-column-end: 12;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6565-055fd1d7 {
+    grid-column: 2 / 4;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6566-055fd1d7 {
+    grid-column: 2 / 8;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6567-055fd1d7 {
+    grid-column-start: 5;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6568-055fd1d7 {
+    grid-column-end: 7;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6584-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6585-055fd1d7 {
+    grid-row: 1 / 5;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e65ad-055fd1d7 {
+    order: -9999;
+    grid-area: span 1 / span 2 / span 1 / span 2;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e65b0-055fd1d7 {
+    order: 9999;
+    grid-area: span 1 / span 2 / span 1 / span 2;
+  }
+
+  #w-node-_026bb609-41ff-e8dc-7098-9278fac19805-fac197f7.w-node-_8b7dc65c-6ccd-ef76-b980-6f80d8a3b84c-0653ac4e {
+    grid-column: span 1 / span 1;
+  }
+
+  #w-node-_04da3743-9ce2-6e2d-ee03-df10a8aa6687-6c55b82b.w-node-b7669384-f90d-3abf-488f-b1efb7b2bf3f-869f6535 {
+    order: -9999;
+  }
+}
+
+@media screen and (max-width: 479px) {
+  #w-node-_851d61a1-1dad-400a-5b6a-92b99f998536-b17c3d94.w-node-_8489c8c1-07dc-6ab4-cde4-f5c814a2d0ce-14a2d0cb {
+    grid-column: span 1 / span 1;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6530-055fd1d7 {
+    grid-column-end: 4;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6531-055fd1d7 {
+    grid-column-end: 12;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6532-055fd1d7 {
+    grid-column-end: 8;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6533-055fd1d7 {
+    grid-column-start: 3;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6534-055fd1d7 {
+    grid-column-end: 13;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e653e-055fd1d7, #w-node-_6401b070-0ac8-bcf0-2647-73725f5e653f-055fd1d7 {
+    grid-area: span 1 / span 2 / span 1 / span 2;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655a-055fd1d7 {
+    grid-column-end: 4;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655b-055fd1d7 {
+    grid-column-end: 12;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655c-055fd1d7 {
+    grid-column-end: 8;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655d-055fd1d7 {
+    grid-column-start: 3;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e655e-055fd1d7 {
+    grid-column-end: 13;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6565-055fd1d7 {
+    grid-column-end: 5;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e6568-055fd1d7 {
+    grid-column-end: 8;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a1-055fd1d7 {
+    grid-column-end: 6;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a2-055fd1d7 {
+    grid-column-start: 2;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a3-055fd1d7 {
+    grid-column-start: 1;
+  }
+
+  #w-node-_6401b070-0ac8-bcf0-2647-73725f5e65a4-055fd1d7 {
+    grid-column-end: 7;
+  }
+
+  #w-node-_54aa7a73-9cec-1e95-d1b2-f0cc4cd7feab-b1f84ccf.w-node-e5bc7b60-f4e5-2026-adc4-34e1d311b11c-df7276e1, #w-node-_25f8541a-af87-b3be-dfd7-8e4c62557276-b1f84ccf.w-node-e5bc7b60-f4e5-2026-adc4-34e1d311b11e-df7276e1, #w-node-_2ef895df-c773-26eb-4339-f405e0068865-b1f84ccf.w-node-e5bc7b60-f4e5-2026-adc4-34e1d311b120-df7276e1 {
+    grid-area: span 1 / span 1 / span 1 / span 1;
+  }
+}
+
+

--- a/src/assets/css/normalize.css
+++ b/src/assets/css/normalize.css
@@ -1,0 +1,355 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+html {
+  font-family: sans-serif;
+  /* 1 */
+  -ms-text-size-adjust: 100%;
+  /* 2 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+}
+/**
+ * Remove default margin.
+ */
+body {
+  margin: 0;
+}
+/* HTML5 display definitions
+   ========================================================================== */
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  /* 1 */
+  vertical-align: baseline;
+  /* 2 */
+}
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+[hidden],
+template {
+  display: none;
+}
+/* Links
+   ========================================================================== */
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+a {
+  background-color: transparent;
+}
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+a:active,
+a:hover {
+  outline: 0;
+}
+/* Text-level semantics
+   ========================================================================== */
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+b,
+strong {
+  font-weight: bold;
+}
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+dfn {
+  font-style: italic;
+}
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+/**
+ * Address styling not present in IE 8/9.
+ */
+mark {
+  background: #ff0;
+  color: #000;
+}
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+small {
+  font-size: 80%;
+}
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+/* Embedded content
+   ========================================================================== */
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+img {
+  border: 0;
+}
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+svg:not(:root) {
+  overflow: hidden;
+}
+/* Grouping content
+   ========================================================================== */
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+figure {
+  margin: 1em 40px;
+}
+/**
+ * Address differences between Firefox and other browsers.
+ */
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+/**
+ * Contain overflow in all browsers.
+ */
+pre {
+  overflow: auto;
+}
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+/* Forms
+   ========================================================================== */
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+  margin: 0;
+  /* 3 */
+}
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+button {
+  overflow: visible;
+}
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+button,
+select {
+  text-transform: none;
+}
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ * 4. CUSTOM FOR WEBFLOW: Removed the input[type="submit"] selector to reduce
+ *    specificity and defer to the .w-button selector
+ */
+button,
+html input[type="button"],
+input[type="reset"] {
+  -webkit-appearance: button;
+  /* 2 */
+  cursor: pointer;
+  /* 3 */
+}
+/**
+ * Re-set default cursor for disabled elements.
+ */
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+input {
+  line-height: normal;
+}
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+input[type='checkbox'],
+input[type='radio'] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+/**
+ * 1. CUSTOM FOR WEBFLOW: changed from `textfield` to `none` to normalize iOS rounded input
+ * 2. CUSTOM FOR WEBFLOW: box-sizing: content-box rule removed
+ *    (similar to normalize.css >=4.0.0)
+ */
+input[type='search'] {
+  -webkit-appearance: none;
+  /* 1 */
+}
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+/**
+ * Define consistent border, margin, and padding.
+ */
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+legend {
+  border: 0;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+textarea {
+  overflow: auto;
+}
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+optgroup {
+  font-weight: bold;
+}
+/* Tables
+   ========================================================================== */
+/**
+ * Remove most spacing between table cells.
+ */
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+td,
+th {
+  padding: 0;
+}

--- a/src/assets/css/webflow.css
+++ b/src/assets/css/webflow.css
@@ -1,0 +1,1790 @@
+@font-face {
+  font-family: 'webflow-icons';
+  src: url("data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg8SBiUAAAC8AAAAYGNtYXDpP+a4AAABHAAAAFxnYXNwAAAAEAAAAXgAAAAIZ2x5ZmhS2XEAAAGAAAADHGhlYWQTFw3HAAAEnAAAADZoaGVhCXYFgQAABNQAAAAkaG10eCe4A1oAAAT4AAAAMGxvY2EDtALGAAAFKAAAABptYXhwABAAPgAABUQAAAAgbmFtZSoCsMsAAAVkAAABznBvc3QAAwAAAAAHNAAAACAAAwP4AZAABQAAApkCzAAAAI8CmQLMAAAB6wAzAQkAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADpAwPA/8AAQAPAAEAAAAABAAAAAAAAAAAAAAAgAAAAAAADAAAAAwAAABwAAQADAAAAHAADAAEAAAAcAAQAQAAAAAwACAACAAQAAQAg5gPpA//9//8AAAAAACDmAOkA//3//wAB/+MaBBcIAAMAAQAAAAAAAAAAAAAAAAABAAH//wAPAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAABAAAAAAAAAAAAAgAANzkBAAAAAAEBIAAAAyADgAAFAAAJAQcJARcDIP5AQAGA/oBAAcABwED+gP6AQAABAOAAAALgA4AABQAAEwEXCQEH4AHAQP6AAYBAAcABwED+gP6AQAAAAwDAAOADQALAAA8AHwAvAAABISIGHQEUFjMhMjY9ATQmByEiBh0BFBYzITI2PQE0JgchIgYdARQWMyEyNj0BNCYDIP3ADRMTDQJADRMTDf3ADRMTDQJADRMTDf3ADRMTDQJADRMTAsATDSANExMNIA0TwBMNIA0TEw0gDRPAEw0gDRMTDSANEwAAAAABAJ0AtAOBApUABQAACQIHCQEDJP7r/upcAXEBcgKU/usBFVz+fAGEAAAAAAL//f+9BAMDwwAEAAkAABcBJwEXAwE3AQdpA5ps/GZsbAOabPxmbEMDmmz8ZmwDmvxmbAOabAAAAgAA/8AEAAPAAB0AOwAABSInLgEnJjU0Nz4BNzYzMTIXHgEXFhUUBw4BBwYjNTI3PgE3NjU0Jy4BJyYjMSIHDgEHBhUUFx4BFxYzAgBqXV6LKCgoKIteXWpqXV6LKCgoKIteXWpVSktvICEhIG9LSlVVSktvICEhIG9LSlVAKCiLXl1qal1eiygoKCiLXl1qal1eiygoZiEgb0tKVVVKS28gISEgb0tKVVVKS28gIQABAAABwAIAA8AAEgAAEzQ3PgE3NjMxFSIHDgEHBhUxIwAoKIteXWpVSktvICFmAcBqXV6LKChmISBvS0pVAAAAAgAA/8AFtgPAADIAOgAAARYXHgEXFhUUBw4BBwYHIxUhIicuAScmNTQ3PgE3NjMxOAExNDc+ATc2MzIXHgEXFhcVATMJATMVMzUEjD83NlAXFxYXTjU1PQL8kz01Nk8XFxcXTzY1PSIjd1BQWlJJSXInJw3+mdv+2/7c25MCUQYcHFg5OUA/ODlXHBwIAhcXTzY1PTw1Nk8XF1tQUHcjIhwcYUNDTgL+3QFt/pOTkwABAAAAAQAAmM7nP18PPPUACwQAAAAAANciZKUAAAAA1yJkpf/9/70FtgPDAAAACAACAAAAAAAAAAEAAAPA/8AAAAW3//3//QW2AAEAAAAAAAAAAAAAAAAAAAAMBAAAAAAAAAAAAAAAAgAAAAQAASAEAADgBAAAwAQAAJ0EAP/9BAAAAAQAAAAFtwAAAAAAAAAKABQAHgAyAEYAjACiAL4BFgE2AY4AAAABAAAADAA8AAMAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAADgCuAAEAAAAAAAEADQAAAAEAAAAAAAIABwCWAAEAAAAAAAMADQBIAAEAAAAAAAQADQCrAAEAAAAAAAUACwAnAAEAAAAAAAYADQBvAAEAAAAAAAoAGgDSAAMAAQQJAAEAGgANAAMAAQQJAAIADgCdAAMAAQQJAAMAGgBVAAMAAQQJAAQAGgC4AAMAAQQJAAUAFgAyAAMAAQQJAAYAGgB8AAMAAQQJAAoANADsd2ViZmxvdy1pY29ucwB3AGUAYgBmAGwAbwB3AC0AaQBjAG8AbgBzVmVyc2lvbiAxLjAAVgBlAHIAcwBpAG8AbgAgADEALgAwd2ViZmxvdy1pY29ucwB3AGUAYgBmAGwAbwB3AC0AaQBjAG8AbgBzd2ViZmxvdy1pY29ucwB3AGUAYgBmAGwAbwB3AC0AaQBjAG8AbgBzUmVndWxhcgBSAGUAZwB1AGwAYQByd2ViZmxvdy1pY29ucwB3AGUAYgBmAGwAbwB3AC0AaQBjAG8AbgBzRm9udCBnZW5lcmF0ZWQgYnkgSWNvTW9vbi4ARgBvAG4AdAAgAGcAZQBuAGUAcgBhAHQAZQBkACAAYgB5ACAASQBjAG8ATQBvAG8AbgAuAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==") format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+[class^="w-icon-"],
+[class*=" w-icon-"] {
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: 'webflow-icons' !important;
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.w-icon-slider-right:before {
+  content: "\e600";
+}
+.w-icon-slider-left:before {
+  content: "\e601";
+}
+.w-icon-nav-menu:before {
+  content: "\e602";
+}
+.w-icon-arrow-down:before,
+.w-icon-dropdown-toggle:before {
+  content: "\e603";
+}
+.w-icon-file-upload-remove:before {
+  content: "\e900";
+}
+.w-icon-file-upload-icon:before {
+  content: "\e903";
+}
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+html {
+  height: 100%;
+}
+body {
+  margin: 0;
+  min-height: 100%;
+  background-color: #fff;
+  font-family: Arial, sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  color: #333;
+}
+img {
+  max-width: 100%;
+  vertical-align: middle;
+  display: inline-block;
+}
+html.w-mod-touch * {
+  background-attachment: scroll !important;
+}
+.w-block {
+  display: block;
+}
+.w-inline-block {
+  max-width: 100%;
+  display: inline-block;
+}
+.w-clearfix:before,
+.w-clearfix:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-clearfix:after {
+  clear: both;
+}
+.w-hidden {
+  display: none;
+}
+.w-button {
+  display: inline-block;
+  padding: 9px 15px;
+  background-color: #3898EC;
+  color: white;
+  border: 0;
+  line-height: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: 0;
+}
+input.w-button {
+  -webkit-appearance: button;
+}
+html[data-w-dynpage] [data-w-cloak] {
+  color: transparent !important;
+}
+.w-code-block {
+  margin: unset;
+}
+pre.w-code-block code {
+  all: inherit;
+}
+.w-optimization {
+  display: contents;
+}
+.w-webflow-badge,
+.w-webflow-badge > img {
+  box-sizing: unset;
+  width: unset;
+  height: unset;
+  max-height: unset;
+  max-width: unset;
+  min-height: unset;
+  min-width: unset;
+  margin: unset;
+  padding: unset;
+  float: unset;
+  clear: unset;
+  border: unset;
+  border-radius: unset;
+  background: unset;
+  background-image: unset;
+  background-position: unset;
+  background-size: unset;
+  background-repeat: unset;
+  background-origin: unset;
+  background-clip: unset;
+  background-attachment: unset;
+  background-color: unset;
+  box-shadow: unset;
+  transform: unset;
+  transition: unset;
+  direction: unset;
+  font-family: unset;
+  font-weight: unset;
+  color: unset;
+  font-size: unset;
+  line-height: unset;
+  font-style: unset;
+  font-variant: unset;
+  text-align: unset;
+  letter-spacing: unset;
+  text-decoration: unset;
+  text-indent: unset;
+  text-transform: unset;
+  list-style-type: unset;
+  text-shadow: unset;
+  vertical-align: unset;
+  cursor: unset;
+  white-space: unset;
+  word-break: unset;
+  word-spacing: unset;
+  word-wrap: unset;
+}
+.w-webflow-badge {
+  position: fixed !important;
+  display: inline-block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  z-index: 2147483647 !important;
+  top: auto !important;
+  right: 12px !important;
+  bottom: 12px !important;
+  left: auto !important;
+  color: #aaadb0 !important;
+  background-color: #fff !important;
+  border-radius: 3px !important;
+  padding: 6px !important;
+  font-size: 12px !important;
+  line-height: 14px !important;
+  text-decoration: none !important;
+  transform: none !important;
+  margin: 0 !important;
+  width: auto !important;
+  height: auto !important;
+  overflow: unset !important;
+  white-space: nowrap;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0px 1px 3px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+}
+.w-webflow-badge > img {
+  position: unset;
+  display: inline-block !important;
+  visibility: unset !important;
+  opacity: 1 !important;
+  vertical-align: middle !important;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+h1 {
+  font-size: 38px;
+  line-height: 44px;
+  margin-top: 20px;
+}
+h2 {
+  font-size: 32px;
+  line-height: 36px;
+  margin-top: 20px;
+}
+h3 {
+  font-size: 24px;
+  line-height: 30px;
+  margin-top: 20px;
+}
+h4 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 10px;
+}
+h5 {
+  font-size: 14px;
+  line-height: 20px;
+  margin-top: 10px;
+}
+h6 {
+  font-size: 12px;
+  line-height: 18px;
+  margin-top: 10px;
+}
+p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+blockquote {
+  margin: 0 0 10px 0;
+  padding: 10px 20px;
+  border-left: 5px solid #E2E2E2;
+  font-size: 18px;
+  line-height: 22px;
+}
+figure {
+  margin: 0;
+  margin-bottom: 10px;
+}
+figcaption {
+  margin-top: 5px;
+  text-align: center;
+}
+ul,
+ol {
+  margin-top: 0px;
+  margin-bottom: 10px;
+  padding-left: 40px;
+}
+.w-list-unstyled {
+  padding-left: 0;
+  list-style: none;
+}
+.w-embed:before,
+.w-embed:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-embed:after {
+  clear: both;
+}
+.w-video {
+  width: 100%;
+  position: relative;
+  padding: 0;
+}
+.w-video iframe,
+.w-video object,
+.w-video embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+fieldset {
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+button,
+[type='button'],
+[type='reset'] {
+  border: 0;
+  cursor: pointer;
+  -webkit-appearance: button;
+}
+.w-form {
+  margin: 0 0 15px;
+}
+.w-form-done {
+  display: none;
+  padding: 20px;
+  text-align: center;
+  background-color: #dddddd;
+}
+.w-form-fail {
+  display: none;
+  margin-top: 10px;
+  padding: 10px;
+  background-color: #ffdede;
+}
+label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+.w-input,
+.w-select {
+  display: block;
+  width: 100%;
+  height: 38px;
+  padding: 8px 12px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  line-height: 1.42857143;
+  color: #333333;
+  vertical-align: middle;
+  background-color: #ffffff;
+  border: 1px solid #cccccc;
+}
+.w-input::placeholder,
+.w-select::placeholder {
+  color: #999;
+}
+.w-input:focus,
+.w-select:focus {
+  border-color: #3898EC;
+  outline: 0;
+}
+.w-input[disabled],
+.w-select[disabled],
+.w-input[readonly],
+.w-select[readonly],
+fieldset[disabled] .w-input,
+fieldset[disabled] .w-select {
+  cursor: not-allowed;
+}
+.w-input[disabled]:not(.w-input-disabled),
+.w-select[disabled]:not(.w-input-disabled),
+.w-input[readonly],
+.w-select[readonly],
+fieldset[disabled]:not(.w-input-disabled) .w-input,
+fieldset[disabled]:not(.w-input-disabled) .w-select {
+  background-color: #eeeeee;
+}
+textarea.w-input,
+textarea.w-select {
+  height: auto;
+}
+.w-select {
+  background-color: #f3f3f3;
+}
+.w-select[multiple] {
+  height: auto;
+}
+.w-form-label {
+  display: inline-block;
+  cursor: pointer;
+  font-weight: normal;
+  margin-bottom: 0px;
+}
+.w-radio {
+  display: block;
+  margin-bottom: 5px;
+  padding-left: 20px;
+}
+.w-radio:before,
+.w-radio:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-radio:after {
+  clear: both;
+}
+.w-radio-input {
+  margin: 4px 0 0;
+  line-height: normal;
+  float: left;
+  margin-left: -20px;
+}
+.w-radio-input {
+  margin-top: 3px;
+}
+.w-file-upload {
+  display: block;
+  margin-bottom: 10px;
+}
+.w-file-upload-input {
+  width: 0.1px;
+  height: 0.1px;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  z-index: -100;
+}
+.w-file-upload-default,
+.w-file-upload-uploading,
+.w-file-upload-success {
+  display: inline-block;
+  color: #333333;
+}
+.w-file-upload-error {
+  display: block;
+  margin-top: 10px;
+}
+.w-file-upload-default.w-hidden,
+.w-file-upload-uploading.w-hidden,
+.w-file-upload-error.w-hidden,
+.w-file-upload-success.w-hidden {
+  display: none;
+}
+.w-file-upload-uploading-btn {
+  display: flex;
+  font-size: 14px;
+  font-weight: normal;
+  cursor: pointer;
+  margin: 0;
+  padding: 8px 12px;
+  border: 1px solid #cccccc;
+  background-color: #fafafa;
+}
+.w-file-upload-file {
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+  margin: 0;
+  padding: 8px 9px 8px 11px;
+  border: 1px solid #cccccc;
+  background-color: #fafafa;
+}
+.w-file-upload-file-name {
+  font-size: 14px;
+  font-weight: normal;
+  display: block;
+}
+.w-file-remove-link {
+  margin-top: 3px;
+  margin-left: 10px;
+  width: auto;
+  height: auto;
+  padding: 3px;
+  display: block;
+  cursor: pointer;
+}
+.w-icon-file-upload-remove {
+  margin: auto;
+  font-size: 10px;
+}
+.w-file-upload-error-msg {
+  display: inline-block;
+  color: #ea384c;
+  padding: 2px 0;
+}
+.w-file-upload-info {
+  display: inline-block;
+  line-height: 38px;
+  padding: 0 12px;
+}
+.w-file-upload-label {
+  display: inline-block;
+  font-size: 14px;
+  font-weight: normal;
+  cursor: pointer;
+  margin: 0;
+  padding: 8px 12px;
+  border: 1px solid #cccccc;
+  background-color: #fafafa;
+}
+.w-icon-file-upload-icon,
+.w-icon-file-upload-uploading {
+  display: inline-block;
+  margin-right: 8px;
+  width: 20px;
+}
+.w-icon-file-upload-uploading {
+  height: 20px;
+}
+.w-container {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 940px;
+}
+.w-container:before,
+.w-container:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-container:after {
+  clear: both;
+}
+.w-container .w-row {
+  margin-left: -10px;
+  margin-right: -10px;
+}
+.w-row:before,
+.w-row:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-row:after {
+  clear: both;
+}
+.w-row .w-row {
+  margin-left: 0;
+  margin-right: 0;
+}
+.w-col {
+  position: relative;
+  float: left;
+  width: 100%;
+  min-height: 1px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+.w-col .w-col {
+  padding-left: 0;
+  padding-right: 0;
+}
+.w-col-1 {
+  width: 8.33333333%;
+}
+.w-col-2 {
+  width: 16.66666667%;
+}
+.w-col-3 {
+  width: 25%;
+}
+.w-col-4 {
+  width: 33.33333333%;
+}
+.w-col-5 {
+  width: 41.66666667%;
+}
+.w-col-6 {
+  width: 50%;
+}
+.w-col-7 {
+  width: 58.33333333%;
+}
+.w-col-8 {
+  width: 66.66666667%;
+}
+.w-col-9 {
+  width: 75%;
+}
+.w-col-10 {
+  width: 83.33333333%;
+}
+.w-col-11 {
+  width: 91.66666667%;
+}
+.w-col-12 {
+  width: 100%;
+}
+.w-hidden-main {
+  display: none !important;
+}
+@media screen and (max-width: 991px) {
+  .w-container {
+    max-width: 728px;
+  }
+  .w-hidden-main {
+    display: inherit !important;
+  }
+  .w-hidden-medium {
+    display: none !important;
+  }
+  .w-col-medium-1 {
+    width: 8.33333333%;
+  }
+  .w-col-medium-2 {
+    width: 16.66666667%;
+  }
+  .w-col-medium-3 {
+    width: 25%;
+  }
+  .w-col-medium-4 {
+    width: 33.33333333%;
+  }
+  .w-col-medium-5 {
+    width: 41.66666667%;
+  }
+  .w-col-medium-6 {
+    width: 50%;
+  }
+  .w-col-medium-7 {
+    width: 58.33333333%;
+  }
+  .w-col-medium-8 {
+    width: 66.66666667%;
+  }
+  .w-col-medium-9 {
+    width: 75%;
+  }
+  .w-col-medium-10 {
+    width: 83.33333333%;
+  }
+  .w-col-medium-11 {
+    width: 91.66666667%;
+  }
+  .w-col-medium-12 {
+    width: 100%;
+  }
+  .w-col-stack {
+    width: 100%;
+    left: auto;
+    right: auto;
+  }
+}
+@media screen and (max-width: 767px) {
+  .w-hidden-main {
+    display: inherit !important;
+  }
+  .w-hidden-medium {
+    display: inherit !important;
+  }
+  .w-hidden-small {
+    display: none !important;
+  }
+  .w-row,
+  .w-container .w-row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .w-col {
+    width: 100%;
+    left: auto;
+    right: auto;
+  }
+  .w-col-small-1 {
+    width: 8.33333333%;
+  }
+  .w-col-small-2 {
+    width: 16.66666667%;
+  }
+  .w-col-small-3 {
+    width: 25%;
+  }
+  .w-col-small-4 {
+    width: 33.33333333%;
+  }
+  .w-col-small-5 {
+    width: 41.66666667%;
+  }
+  .w-col-small-6 {
+    width: 50%;
+  }
+  .w-col-small-7 {
+    width: 58.33333333%;
+  }
+  .w-col-small-8 {
+    width: 66.66666667%;
+  }
+  .w-col-small-9 {
+    width: 75%;
+  }
+  .w-col-small-10 {
+    width: 83.33333333%;
+  }
+  .w-col-small-11 {
+    width: 91.66666667%;
+  }
+  .w-col-small-12 {
+    width: 100%;
+  }
+}
+@media screen and (max-width: 479px) {
+  .w-container {
+    max-width: none;
+  }
+  .w-hidden-main {
+    display: inherit !important;
+  }
+  .w-hidden-medium {
+    display: inherit !important;
+  }
+  .w-hidden-small {
+    display: inherit !important;
+  }
+  .w-hidden-tiny {
+    display: none !important;
+  }
+  .w-col {
+    width: 100%;
+  }
+  .w-col-tiny-1 {
+    width: 8.33333333%;
+  }
+  .w-col-tiny-2 {
+    width: 16.66666667%;
+  }
+  .w-col-tiny-3 {
+    width: 25%;
+  }
+  .w-col-tiny-4 {
+    width: 33.33333333%;
+  }
+  .w-col-tiny-5 {
+    width: 41.66666667%;
+  }
+  .w-col-tiny-6 {
+    width: 50%;
+  }
+  .w-col-tiny-7 {
+    width: 58.33333333%;
+  }
+  .w-col-tiny-8 {
+    width: 66.66666667%;
+  }
+  .w-col-tiny-9 {
+    width: 75%;
+  }
+  .w-col-tiny-10 {
+    width: 83.33333333%;
+  }
+  .w-col-tiny-11 {
+    width: 91.66666667%;
+  }
+  .w-col-tiny-12 {
+    width: 100%;
+  }
+}
+.w-widget {
+  position: relative;
+}
+.w-widget-map {
+  width: 100%;
+  height: 400px;
+}
+.w-widget-map label {
+  width: auto;
+  display: inline;
+}
+.w-widget-map img {
+  max-width: inherit;
+}
+.w-widget-map .gm-style-iw {
+  text-align: center;
+}
+.w-widget-map .gm-style-iw > button {
+  display: none !important;
+}
+.w-widget-twitter {
+  overflow: hidden;
+}
+.w-widget-twitter-count-shim {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 28px;
+  height: 20px;
+  text-align: center;
+  background: white;
+  border: #758696 solid 1px;
+  border-radius: 3px;
+}
+.w-widget-twitter-count-shim * {
+  pointer-events: none;
+  user-select: none;
+}
+.w-widget-twitter-count-shim .w-widget-twitter-count-inner {
+  position: relative;
+  font-size: 15px;
+  line-height: 12px;
+  text-align: center;
+  color: #999;
+  font-family: serif;
+}
+.w-widget-twitter-count-shim .w-widget-twitter-count-clear {
+  position: relative;
+  display: block;
+}
+.w-widget-twitter-count-shim.w--large {
+  width: 36px;
+  height: 28px;
+}
+.w-widget-twitter-count-shim.w--large .w-widget-twitter-count-inner {
+  font-size: 18px;
+  line-height: 18px;
+}
+.w-widget-twitter-count-shim:not(.w--vertical) {
+  margin-left: 5px;
+  margin-right: 8px;
+}
+.w-widget-twitter-count-shim:not(.w--vertical).w--large {
+  margin-left: 6px;
+}
+.w-widget-twitter-count-shim:not(.w--vertical):before,
+.w-widget-twitter-count-shim:not(.w--vertical):after {
+  top: 50%;
+  left: 0;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.w-widget-twitter-count-shim:not(.w--vertical):before {
+  border-color: rgba(117, 134, 150, 0);
+  border-right-color: #5d6c7b;
+  border-width: 4px;
+  margin-left: -9px;
+  margin-top: -4px;
+}
+.w-widget-twitter-count-shim:not(.w--vertical).w--large:before {
+  border-width: 5px;
+  margin-left: -10px;
+  margin-top: -5px;
+}
+.w-widget-twitter-count-shim:not(.w--vertical):after {
+  border-color: rgba(255, 255, 255, 0);
+  border-right-color: white;
+  border-width: 4px;
+  margin-left: -8px;
+  margin-top: -4px;
+}
+.w-widget-twitter-count-shim:not(.w--vertical).w--large:after {
+  border-width: 5px;
+  margin-left: -9px;
+  margin-top: -5px;
+}
+.w-widget-twitter-count-shim.w--vertical {
+  width: 61px;
+  height: 33px;
+  margin-bottom: 8px;
+}
+.w-widget-twitter-count-shim.w--vertical:before,
+.w-widget-twitter-count-shim.w--vertical:after {
+  top: 100%;
+  left: 50%;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.w-widget-twitter-count-shim.w--vertical:before {
+  border-color: rgba(117, 134, 150, 0);
+  border-top-color: #5d6c7b;
+  border-width: 5px;
+  margin-left: -5px;
+}
+.w-widget-twitter-count-shim.w--vertical:after {
+  border-color: rgba(255, 255, 255, 0);
+  border-top-color: white;
+  border-width: 4px;
+  margin-left: -4px;
+}
+.w-widget-twitter-count-shim.w--vertical .w-widget-twitter-count-inner {
+  font-size: 18px;
+  line-height: 22px;
+}
+.w-widget-twitter-count-shim.w--vertical.w--large {
+  width: 76px;
+}
+.w-background-video {
+  position: relative;
+  overflow: hidden;
+  height: 500px;
+  color: white;
+}
+.w-background-video > video {
+  background-size: cover;
+  background-position: 50% 50%;
+  position: absolute;
+  margin: auto;
+  width: 100%;
+  height: 100%;
+  right: -100%;
+  bottom: -100%;
+  top: -100%;
+  left: -100%;
+  object-fit: cover;
+  z-index: -100;
+}
+.w-background-video > video::-webkit-media-controls-start-playback-button {
+  display: none !important;
+  -webkit-appearance: none;
+}
+.w-background-video--control {
+  position: absolute;
+  bottom: 1em;
+  right: 1em;
+  background-color: transparent;
+  padding: 0;
+}
+.w-background-video--control > [hidden] {
+  display: none !important;
+}
+.w-slider {
+  position: relative;
+  height: 300px;
+  text-align: center;
+  background: #dddddd;
+  clear: both;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  tap-highlight-color: rgba(0, 0, 0, 0);
+}
+.w-slider-mask {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  z-index: 1;
+  left: 0;
+  right: 0;
+  height: 100%;
+  white-space: nowrap;
+}
+.w-slide {
+  position: relative;
+  display: inline-block;
+  vertical-align: top;
+  width: 100%;
+  height: 100%;
+  white-space: normal;
+  text-align: left;
+}
+.w-slider-nav {
+  position: absolute;
+  z-index: 2;
+  top: auto;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  padding-top: 10px;
+  height: 40px;
+  text-align: center;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  tap-highlight-color: rgba(0, 0, 0, 0);
+}
+.w-slider-nav.w-round > div {
+  border-radius: 100%;
+}
+.w-slider-nav.w-num > div {
+  width: auto;
+  height: auto;
+  padding: 0.2em 0.5em;
+  font-size: inherit;
+  line-height: inherit;
+}
+.w-slider-nav.w-shadow > div {
+  box-shadow: 0 0 3px rgba(51, 51, 51, 0.4);
+}
+.w-slider-nav-invert {
+  color: #fff;
+}
+.w-slider-nav-invert > div {
+  background-color: rgba(34, 34, 34, 0.4);
+}
+.w-slider-nav-invert > div.w-active {
+  background-color: #222;
+}
+.w-slider-dot {
+  position: relative;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  background-color: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  margin: 0 3px 0.5em;
+  transition: background-color 100ms, color 100ms;
+}
+.w-slider-dot.w-active {
+  background-color: #fff;
+}
+.w-slider-dot:focus {
+  outline: none;
+  box-shadow: 0px 0px 0px 2px #fff;
+}
+.w-slider-dot:focus.w-active {
+  box-shadow: none;
+}
+.w-slider-arrow-left,
+.w-slider-arrow-right {
+  position: absolute;
+  width: 80px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  cursor: pointer;
+  overflow: hidden;
+  color: white;
+  font-size: 40px;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  tap-highlight-color: rgba(0, 0, 0, 0);
+  user-select: none;
+}
+.w-slider-arrow-left [class^='w-icon-'],
+.w-slider-arrow-right [class^='w-icon-'],
+.w-slider-arrow-left [class*=' w-icon-'],
+.w-slider-arrow-right [class*=' w-icon-'] {
+  position: absolute;
+}
+.w-slider-arrow-left:focus,
+.w-slider-arrow-right:focus {
+  outline: 0;
+}
+.w-slider-arrow-left {
+  z-index: 3;
+  right: auto;
+}
+.w-slider-arrow-right {
+  z-index: 4;
+  left: auto;
+}
+.w-icon-slider-left,
+.w-icon-slider-right {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  width: 1em;
+  height: 1em;
+}
+.w-slider-aria-label {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.w-slider-force-show {
+  display: block !important;
+}
+.w-dropdown {
+  display: inline-block;
+  position: relative;
+  text-align: left;
+  margin-left: auto;
+  margin-right: auto;
+  z-index: 900;
+}
+.w-dropdown-btn,
+.w-dropdown-toggle,
+.w-dropdown-link {
+  position: relative;
+  vertical-align: top;
+  text-decoration: none;
+  color: #222222;
+  padding: 20px;
+  text-align: left;
+  margin-left: auto;
+  margin-right: auto;
+  white-space: nowrap;
+}
+.w-dropdown-toggle {
+  user-select: none;
+  display: inline-block;
+  cursor: pointer;
+  padding-right: 40px;
+}
+.w-dropdown-toggle:focus {
+  outline: 0;
+}
+.w-icon-dropdown-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  margin-right: 20px;
+  width: 1em;
+  height: 1em;
+}
+.w-dropdown-list {
+  position: absolute;
+  background: #dddddd;
+  display: none;
+  min-width: 100%;
+}
+.w-dropdown-list.w--open {
+  display: block;
+}
+.w-dropdown-link {
+  padding: 10px 20px;
+  display: block;
+  color: #222222;
+}
+.w-dropdown-link.w--current {
+  color: #0082f3;
+}
+.w-dropdown-link:focus {
+  outline: 0;
+}
+@media screen and (max-width: 767px) {
+  .w-nav-brand {
+    padding-left: 10px;
+  }
+}
+/**
+ * ## Note
+ * Safari (on both iOS and OS X) does not handle viewport units (vh, vw) well.
+ * For example percentage units do not work on descendants of elements that
+ * have any dimensions expressed in viewport units. It also doesn’t handle them at
+ * all in `calc()`.
+ */
+/**
+ * Wrapper around all lightbox elements
+ *
+ * 1. Since the lightbox can receive focus, IE also gives it an outline.
+ * 2. Fixes flickering on Chrome when a transition is in progress
+ *    underneath the lightbox.
+ */
+.w-lightbox-backdrop {
+  cursor: auto;
+  font-style: normal;
+  letter-spacing: normal;
+  list-style: disc;
+  text-indent: 0;
+  text-shadow: none;
+  text-transform: none;
+  visibility: visible;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  color: #fff;
+  font-family: "Helvetica Neue", Helvetica, Ubuntu, "Segoe UI", Verdana, sans-serif;
+  font-size: 17px;
+  line-height: 1.2;
+  font-weight: 300;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.9);
+  z-index: 2000;
+  outline: 0;
+  /* 1 */
+  opacity: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-transform: translate(0, 0);
+  /* 2 */
+}
+/**
+ * Neat trick to bind the rubberband effect to our canvas instead of the whole
+ * document on iOS. It also prevents a bug that causes the document underneath to scroll.
+ */
+.w-lightbox-backdrop,
+.w-lightbox-container {
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.w-lightbox-content {
+  position: relative;
+  height: 100vh;
+  overflow: hidden;
+}
+.w-lightbox-view {
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  opacity: 0;
+}
+.w-lightbox-view:before {
+  content: "";
+  height: 100vh;
+}
+/* .w-lightbox-content */
+.w-lightbox-group,
+.w-lightbox-group .w-lightbox-view,
+.w-lightbox-group .w-lightbox-view:before {
+  height: 86vh;
+}
+.w-lightbox-frame,
+.w-lightbox-view:before {
+  display: inline-block;
+  vertical-align: middle;
+}
+/*
+ * 1. Remove default margin set by user-agent on the <figure> element.
+ */
+.w-lightbox-figure {
+  position: relative;
+  margin: 0;
+  /* 1 */
+}
+.w-lightbox-group .w-lightbox-figure {
+  cursor: pointer;
+}
+/**
+ * IE adds image dimensions as width and height attributes on the IMG tag,
+ * but we need both width and height to be set to auto to enable scaling.
+ */
+.w-lightbox-img {
+  width: auto;
+  height: auto;
+  max-width: none;
+}
+/**
+ * 1. Reset if style is set by user on "All Images"
+ */
+.w-lightbox-image {
+  display: block;
+  float: none;
+  /* 1 */
+  max-width: 100vw;
+  max-height: 100vh;
+}
+.w-lightbox-group .w-lightbox-image {
+  max-height: 86vh;
+}
+.w-lightbox-caption {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 0.5em 1em;
+  background: rgba(0, 0, 0, 0.4);
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.w-lightbox-embed {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.w-lightbox-control {
+  position: absolute;
+  top: 0;
+  width: 4em;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  cursor: pointer;
+  -webkit-transition: all 0.3s;
+  transition: all 0.3s;
+}
+.w-lightbox-left {
+  display: none;
+  bottom: 0;
+  left: 0;
+  /* <svg xmlns="http://www.w3.org/2000/svg" viewBox="-20 0 24 40" width="24" height="40"><g transform="rotate(45)"><path d="m0 0h5v23h23v5h-28z" opacity=".4"/><path d="m1 1h3v23h23v3h-26z" fill="#fff"/></g></svg> */
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0yMCAwIDI0IDQwIiB3aWR0aD0iMjQiIGhlaWdodD0iNDAiPjxnIHRyYW5zZm9ybT0icm90YXRlKDQ1KSI+PHBhdGggZD0ibTAgMGg1djIzaDIzdjVoLTI4eiIgb3BhY2l0eT0iLjQiLz48cGF0aCBkPSJtMSAxaDN2MjNoMjN2M2gtMjZ6IiBmaWxsPSIjZmZmIi8+PC9nPjwvc3ZnPg==");
+}
+.w-lightbox-right {
+  display: none;
+  right: 0;
+  bottom: 0;
+  /* <svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 0 24 40" width="24" height="40"><g transform="rotate(45)"><path d="m0-0h28v28h-5v-23h-23z" opacity=".4"/><path d="m1 1h26v26h-3v-23h-23z" fill="#fff"/></g></svg> */
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii00IDAgMjQgNDAiIHdpZHRoPSIyNCIgaGVpZ2h0PSI0MCI+PGcgdHJhbnNmb3JtPSJyb3RhdGUoNDUpIj48cGF0aCBkPSJtMC0waDI4djI4aC01di0yM2gtMjN6IiBvcGFjaXR5PSIuNCIvPjxwYXRoIGQ9Im0xIDFoMjZ2MjZoLTN2LTIzaC0yM3oiIGZpbGw9IiNmZmYiLz48L2c+PC9zdmc+");
+}
+/*
+ * Without specifying the with and height inside the SVG, all versions of IE render the icon too small.
+ * The bug does not seem to manifest itself if the elements are tall enough such as the above arrows.
+ * (http://stackoverflow.com/questions/16092114/background-size-differs-in-internet-explorer)
+ */
+.w-lightbox-close {
+  right: 0;
+  height: 2.6em;
+  /* <svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 0 18 17" width="18" height="17"><g transform="rotate(45)"><path d="m0 0h7v-7h5v7h7v5h-7v7h-5v-7h-7z" opacity=".4"/><path d="m1 1h7v-7h3v7h7v3h-7v7h-3v-7h-7z" fill="#fff"/></g></svg> */
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii00IDAgMTggMTciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxNyI+PGcgdHJhbnNmb3JtPSJyb3RhdGUoNDUpIj48cGF0aCBkPSJtMCAwaDd2LTdoNXY3aDd2NWgtN3Y3aC01di03aC03eiIgb3BhY2l0eT0iLjQiLz48cGF0aCBkPSJtMSAxaDd2LTdoM3Y3aDd2M2gtN3Y3aC0zdi03aC03eiIgZmlsbD0iI2ZmZiIvPjwvZz48L3N2Zz4=");
+  background-size: 18px;
+}
+/**
+ * 1. All IE versions add extra space at the bottom without this.
+ */
+.w-lightbox-strip {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0 1vh;
+  line-height: 0;
+  /* 1 */
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+/*
+ * 1. We use content-box to avoid having to do `width: calc(10vh + 2vw)`
+ *    which doesn’t work in Safari anyway.
+ * 2. Chrome renders images pixelated when switching to GPU. Making sure
+ *    the parent is also rendered on the GPU (by setting translate3d for
+ *    example) fixes this behavior.
+ */
+.w-lightbox-item {
+  display: inline-block;
+  width: 10vh;
+  padding: 2vh 1vh;
+  box-sizing: content-box;
+  /* 1 */
+  cursor: pointer;
+  -webkit-transform: translate3d(0, 0, 0);
+  /* 2 */
+}
+.w-lightbox-active {
+  opacity: 0.3;
+}
+.w-lightbox-thumbnail {
+  position: relative;
+  height: 10vh;
+  background: #222;
+  overflow: hidden;
+}
+.w-lightbox-thumbnail-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.w-lightbox-thumbnail .w-lightbox-tall {
+  top: 50%;
+  width: 100%;
+  -webkit-transform: translate(0, -50%);
+  transform: translate(0, -50%);
+}
+.w-lightbox-thumbnail .w-lightbox-wide {
+  left: 50%;
+  height: 100%;
+  -webkit-transform: translate(-50%, 0);
+  transform: translate(-50%, 0);
+}
+/*
+ * Spinner
+ *
+ * Absolute pixel values are used to avoid rounding errors that would cause
+ * the white spinning element to be misaligned with the track.
+ */
+.w-lightbox-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  box-sizing: border-box;
+  width: 40px;
+  height: 40px;
+  margin-top: -20px;
+  margin-left: -20px;
+  border: 5px solid rgba(0, 0, 0, 0.4);
+  border-radius: 50%;
+  -webkit-animation: spin 0.8s infinite linear;
+  animation: spin 0.8s infinite linear;
+}
+.w-lightbox-spinner:after {
+  content: "";
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border: 3px solid transparent;
+  border-bottom-color: #fff;
+  border-radius: 50%;
+}
+/*
+ * Utility classes
+ */
+.w-lightbox-hide {
+  display: none;
+}
+.w-lightbox-noscroll {
+  overflow: hidden;
+}
+@media (min-width: 768px) {
+  .w-lightbox-content {
+    height: 96vh;
+    margin-top: 2vh;
+  }
+  .w-lightbox-view,
+  .w-lightbox-view:before {
+    height: 96vh;
+  }
+  /* .w-lightbox-content */
+  .w-lightbox-group,
+  .w-lightbox-group .w-lightbox-view,
+  .w-lightbox-group .w-lightbox-view:before {
+    height: 84vh;
+  }
+  .w-lightbox-image {
+    max-width: 96vw;
+    max-height: 96vh;
+  }
+  .w-lightbox-group .w-lightbox-image {
+    max-width: 82.3vw;
+    max-height: 84vh;
+  }
+  .w-lightbox-left,
+  .w-lightbox-right {
+    display: block;
+    opacity: 0.5;
+  }
+  .w-lightbox-close {
+    opacity: 0.8;
+  }
+  .w-lightbox-control:hover {
+    opacity: 1;
+  }
+}
+.w-lightbox-inactive,
+.w-lightbox-inactive:hover {
+  opacity: 0;
+}
+.w-richtext:before,
+.w-richtext:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-richtext:after {
+  clear: both;
+}
+.w-richtext[contenteditable="true"]:before,
+.w-richtext[contenteditable="true"]:after {
+  white-space: initial;
+}
+.w-richtext ol,
+.w-richtext ul {
+  overflow: hidden;
+}
+.w-richtext .w-richtext-figure-selected.w-richtext-figure-type-video div:after,
+.w-richtext .w-richtext-figure-selected[data-rt-type="video"] div:after {
+  outline: 2px solid #2895f7;
+}
+.w-richtext .w-richtext-figure-selected.w-richtext-figure-type-image div,
+.w-richtext .w-richtext-figure-selected[data-rt-type="image"] div {
+  outline: 2px solid #2895f7;
+}
+.w-richtext figure.w-richtext-figure-type-video > div:after,
+.w-richtext figure[data-rt-type="video"] > div:after {
+  content: '';
+  position: absolute;
+  display: none;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+.w-richtext figure {
+  position: relative;
+  max-width: 60%;
+}
+.w-richtext figure > div:before {
+  cursor: default!important;
+}
+.w-richtext figure img {
+  width: 100%;
+}
+.w-richtext figure figcaption.w-richtext-figcaption-placeholder {
+  opacity: 0.6;
+}
+.w-richtext figure div {
+  /* fix incorrectly sized selection border in the data manager */
+  font-size: 0px;
+  color: transparent;
+}
+.w-richtext figure.w-richtext-figure-type-image,
+.w-richtext figure[data-rt-type="image"] {
+  display: table;
+}
+.w-richtext figure.w-richtext-figure-type-image > div,
+.w-richtext figure[data-rt-type="image"] > div {
+  display: inline-block;
+}
+.w-richtext figure.w-richtext-figure-type-image > figcaption,
+.w-richtext figure[data-rt-type="image"] > figcaption {
+  display: table-caption;
+  caption-side: bottom;
+}
+.w-richtext figure.w-richtext-figure-type-video,
+.w-richtext figure[data-rt-type="video"] {
+  width: 60%;
+  height: 0;
+}
+.w-richtext figure.w-richtext-figure-type-video iframe,
+.w-richtext figure[data-rt-type="video"] iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.w-richtext figure.w-richtext-figure-type-video > div,
+.w-richtext figure[data-rt-type="video"] > div {
+  width: 100%;
+}
+.w-richtext figure.w-richtext-align-center {
+  margin-right: auto;
+  margin-left: auto;
+  clear: both;
+}
+.w-richtext figure.w-richtext-align-center.w-richtext-figure-type-image > div,
+.w-richtext figure.w-richtext-align-center[data-rt-type="image"] > div {
+  max-width: 100%;
+}
+.w-richtext figure.w-richtext-align-normal {
+  clear: both;
+}
+.w-richtext figure.w-richtext-align-fullwidth {
+  width: 100%;
+  max-width: 100%;
+  text-align: center;
+  clear: both;
+  display: block;
+  margin-right: auto;
+  margin-left: auto;
+}
+.w-richtext figure.w-richtext-align-fullwidth > div {
+  display: inline-block;
+  /* padding-bottom is used for aspect ratios in video figures
+      we want the div to inherit that so hover/selection borders in the designer-canvas
+      fit right*/
+  padding-bottom: inherit;
+}
+.w-richtext figure.w-richtext-align-fullwidth > figcaption {
+  display: block;
+}
+.w-richtext figure.w-richtext-align-floatleft {
+  float: left;
+  margin-right: 15px;
+  clear: none;
+}
+.w-richtext figure.w-richtext-align-floatright {
+  float: right;
+  margin-left: 15px;
+  clear: none;
+}
+.w-nav {
+  position: relative;
+  background: #dddddd;
+  z-index: 1000;
+}
+.w-nav:before,
+.w-nav:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-nav:after {
+  clear: both;
+}
+.w-nav-brand {
+  position: relative;
+  float: left;
+  text-decoration: none;
+  color: #333333;
+}
+.w-nav-link {
+  position: relative;
+  display: inline-block;
+  vertical-align: top;
+  text-decoration: none;
+  color: #222222;
+  padding: 20px;
+  text-align: left;
+  margin-left: auto;
+  margin-right: auto;
+}
+.w-nav-link.w--current {
+  color: #0082f3;
+}
+.w-nav-menu {
+  position: relative;
+  float: right;
+}
+[data-nav-menu-open] {
+  display: block !important;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #C8C8C8;
+  text-align: center;
+  overflow: visible;
+  min-width: 200px;
+}
+.w--nav-link-open {
+  display: block;
+  position: relative;
+}
+.w-nav-overlay {
+  position: absolute;
+  overflow: hidden;
+  display: none;
+  top: 100%;
+  left: 0;
+  right: 0;
+  width: 100%;
+}
+.w-nav-overlay [data-nav-menu-open] {
+  top: 0;
+}
+.w-nav[data-animation='over-left'] .w-nav-overlay {
+  width: auto;
+}
+.w-nav[data-animation='over-left'] .w-nav-overlay,
+.w-nav[data-animation='over-left'] [data-nav-menu-open] {
+  right: auto;
+  z-index: 1;
+  top: 0;
+}
+.w-nav[data-animation='over-right'] .w-nav-overlay {
+  width: auto;
+}
+.w-nav[data-animation='over-right'] .w-nav-overlay,
+.w-nav[data-animation='over-right'] [data-nav-menu-open] {
+  left: auto;
+  z-index: 1;
+  top: 0;
+}
+.w-nav-button {
+  position: relative;
+  float: right;
+  padding: 18px;
+  font-size: 24px;
+  display: none;
+  cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  tap-highlight-color: rgba(0, 0, 0, 0);
+  user-select: none;
+}
+.w-nav-button:focus {
+  outline: 0;
+}
+.w-nav-button.w--open {
+  background-color: #C8C8C8;
+  color: white;
+}
+.w-nav[data-collapse='all'] .w-nav-menu {
+  display: none;
+}
+.w-nav[data-collapse='all'] .w-nav-button {
+  display: block;
+}
+.w--nav-dropdown-open {
+  display: block;
+}
+.w--nav-dropdown-toggle-open {
+  display: block;
+}
+.w--nav-dropdown-list-open {
+  position: static;
+}
+@media screen and (max-width: 991px) {
+  .w-nav[data-collapse='medium'] .w-nav-menu {
+    display: none;
+  }
+  .w-nav[data-collapse='medium'] .w-nav-button {
+    display: block;
+  }
+}
+@media screen and (max-width: 767px) {
+  .w-nav[data-collapse='small'] .w-nav-menu {
+    display: none;
+  }
+  .w-nav[data-collapse='small'] .w-nav-button {
+    display: block;
+  }
+  .w-nav-brand {
+    padding-left: 10px;
+  }
+}
+@media screen and (max-width: 479px) {
+  .w-nav[data-collapse='tiny'] .w-nav-menu {
+    display: none;
+  }
+  .w-nav[data-collapse='tiny'] .w-nav-button {
+    display: block;
+  }
+}
+.w-tabs {
+  position: relative;
+}
+.w-tabs:before,
+.w-tabs:after {
+  content: " ";
+  display: table;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  grid-column-end: 2;
+  grid-row-end: 2;
+}
+.w-tabs:after {
+  clear: both;
+}
+.w-tab-menu {
+  position: relative;
+}
+.w-tab-link {
+  position: relative;
+  display: inline-block;
+  vertical-align: top;
+  text-decoration: none;
+  padding: 9px 30px;
+  text-align: left;
+  cursor: pointer;
+  color: #222222;
+  background-color: #dddddd;
+}
+.w-tab-link.w--current {
+  background-color: #C8C8C8;
+}
+.w-tab-link:focus {
+  outline: 0;
+}
+.w-tab-content {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+.w-tab-pane {
+  position: relative;
+  display: none;
+}
+.w--tab-active {
+  display: block;
+}
+@media screen and (max-width: 479px) {
+  .w-tab-link {
+    display: block;
+  }
+}
+.w-ix-emptyfix:after {
+  content: "";
+}
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+.w-dyn-empty {
+  padding: 10px;
+  background-color: #dddddd;
+}
+.w-dyn-hide {
+  display: none !important;
+}
+.w-dyn-bind-empty {
+  display: none !important;
+}
+.w-condition-invisible {
+  display: none !important;
+}
+.wf-layout-layout {
+  display: grid;
+}


### PR DESCRIPTION
## Summary
- add the Webflow-exported CSS assets under `src/assets/css` so they can be imported by the React app
- replace placeholder `background-image` URLs in `jeroen-paws.webflow.css` with `none` to avoid build-time resolution errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc950df18832cabe0cf3837d05010