### PR TITLE
feat: load services page content from supabase

### DIFF
--- a/src/pages/Services/Services.jsx
+++ b/src/pages/Services/Services.jsx
@@ -1,16 +1,142 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import ServicesFeatureSection from './sections/ServicesFeatureSection';
 import ServicesPricingSection from './sections/ServicesPricingSection';
 import ServicesTestimonialsSection from './sections/ServicesTestimonialsSection';
 import ServicesCtaSection from './sections/ServicesCtaSection';
+import ServicesFaqSection from './sections/ServicesFaqSection';
+import { supabase } from '../../supabaseClient';
 
-const Services = () => (
-  <main>
-    <ServicesFeatureSection />
-    <ServicesPricingSection />
-    <ServicesTestimonialsSection />
-    <ServicesCtaSection />
-  </main>
-);
+const SERVICES_PAGE_SLUG = 'services';
+
+const buildCta = (heroEntry) => {
+  if (!heroEntry) {
+    return null;
+  }
+
+  const {
+    heading,
+    primary_cta_label: primaryLabel,
+    primary_cta_url: primaryUrl,
+    secondary_cta_label: secondaryLabel,
+    secondary_cta_url: secondaryUrl,
+  } = heroEntry;
+
+  return {
+    heading: heading || null,
+    primaryCta: primaryLabel && primaryUrl ? { label: primaryLabel, url: primaryUrl } : null,
+    secondaryCta: secondaryLabel && secondaryUrl ? { label: secondaryLabel, url: secondaryUrl } : null,
+  };
+};
+
+const Services = () => {
+  const [servicesHero, setServicesHero] = useState([]);
+  const [carePlans, setCarePlans] = useState([]);
+  const [testimonials, setTestimonials] = useState([]);
+  const [faqs, setFaqs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchServicesContent = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const [heroResponse, carePlanResponse, testimonialResponse, faqResponse] = await Promise.all([
+          supabase
+            .from('services_hero')
+            .select('*')
+            .order('created_at', { ascending: true }),
+          supabase
+            .from('care_plans')
+            .select('*')
+            .order('sort_order', { ascending: true })
+            .order('created_at', { ascending: true }),
+          supabase
+            .from('testimonials')
+            .select('*')
+            .order('display_order', { ascending: true }),
+          supabase
+            .from('services_faq')
+            .select('*')
+            .order('sort_order', { ascending: true })
+            .order('created_at', { ascending: true }),
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        const responseErrors = [
+          heroResponse.error,
+          carePlanResponse.error,
+          testimonialResponse.error,
+          faqResponse.error,
+        ].filter(Boolean);
+
+        if (responseErrors.length > 0) {
+          throw new Error(responseErrors.map((item) => item.message).join(' | '));
+        }
+
+        setServicesHero(heroResponse.data ?? []);
+        setCarePlans(carePlanResponse.data ?? []);
+        setTestimonials(testimonialResponse.data ?? []);
+        setFaqs(faqResponse.data ?? []);
+      } catch (fetchError) {
+        if (isMounted) {
+          setError(fetchError.message);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchServicesContent();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const ctaContent = useMemo(() => buildCta(servicesHero[0]), [servicesHero]);
+
+  const filteredFaqs = useMemo(
+    () =>
+      faqs.filter(
+        (faq) => !faq.service_slug || faq.service_slug === SERVICES_PAGE_SLUG,
+      ),
+    [faqs],
+  );
+
+  return (
+    <main>
+      {(loading || error) && (
+        <section className="section">
+          <div className="container">
+            {loading && <p>Loading services...</p>}
+            {error && (
+              <p role="alert">
+                There was an issue loading the services content. {error}
+              </p>
+            )}
+          </div>
+        </section>
+      )}
+      <ServicesFeatureSection heroEntries={servicesHero} />
+      <ServicesPricingSection carePlans={carePlans} />
+      <ServicesTestimonialsSection testimonials={testimonials} />
+      <ServicesFaqSection faqs={filteredFaqs} />
+      <ServicesCtaSection
+        heading={ctaContent?.heading}
+        primaryCta={ctaContent?.primaryCta}
+        secondaryCta={ctaContent?.secondaryCta}
+      />
+    </main>
+  );
+};
 
 export default Services;

--- a/src/pages/Services/sections/ServicesCtaSection.jsx
+++ b/src/pages/Services/sections/ServicesCtaSection.jsx
@@ -1,18 +1,53 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
-const ServicesCtaSection = () => (
-  <section className="section is-secondary">
+const DEFAULT_HEADING = 'Care your dog deserves';
+const DEFAULT_PRIMARY_CTA = { label: 'Book now', url: '/contact?service=consultation' };
+const DEFAULT_SECONDARY_CTA = { label: 'Contact', url: '/contact' };
+
+const isInternalLink = (url) => typeof url === 'string' && url.startsWith('/');
+
+const CtaButton = ({ cta, variant }) => {
+  if (!cta?.label || !cta?.url) {
+    return null;
+  }
+
+  const className = variant === 'secondary' ? 'button is-secondary w-button' : 'button w-button';
+
+  return isInternalLink(cta.url) ? (
+    <Link to={cta.url} className={className}>
+      {cta.label}
+    </Link>
+  ) : (
+    <a href={cta.url} className={className} target="_blank" rel="noreferrer">
+      {cta.label}
+    </a>
+  );
+};
+
+const ServicesCtaSection = ({ heading, primaryCta, secondaryCta }) => {
+  const resolvedHeading = heading || DEFAULT_HEADING;
+  const { resolvedPrimary, resolvedSecondary } = useMemo(
+    () => ({
+      resolvedPrimary: primaryCta?.label && primaryCta?.url ? primaryCta : DEFAULT_PRIMARY_CTA,
+      resolvedSecondary: secondaryCta?.label && secondaryCta?.url ? secondaryCta : DEFAULT_SECONDARY_CTA,
+    }),
+    [primaryCta, secondaryCta],
+  );
+
+  return (
+    <section className="section is-secondary">
       <div className="container">
         <div className="w-layout-grid grid_2-col tablet-1-col gap-small">
-          <h2 className="margin-bottom_none">Care your dog deserves</h2>
-          <div id="w-node-a0716485-74b7-5610-0f39-21a551ba8ab3-51ba8aae" className="button-group margin-top_none w-node-_8f7bd1a1-5c28-01fc-fedd-74dceca3d3cb-df7276e1">
-            <Link to="/contact?service=consultation" className="button w-button">Book now</Link>
-            <Link to="/contact" className="button is-secondary w-button">Contact</Link>
+          <h2 className="margin-bottom_none">{resolvedHeading}</h2>
+          <div className="button-group margin-top_none">
+            <CtaButton cta={resolvedPrimary} />
+            <CtaButton cta={resolvedSecondary} variant="secondary" />
           </div>
         </div>
       </div>
     </section>
-);
+  );
+};
 
 export default ServicesCtaSection;

--- a/src/pages/Services/sections/ServicesFaqSection.jsx
+++ b/src/pages/Services/sections/ServicesFaqSection.jsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const FALLBACK_FAQS = [
+  {
+    id: 'services-faq-1',
+    question: 'What services do you offer for dogs?',
+    answer:
+      'We provide training, walking, boarding, and day care tailored to each dog. Every plan is customised to support their needs and your schedule.',
+  },
+  {
+    id: 'services-faq-2',
+    question: 'Can you personalise care for my dog?',
+    answer:
+      'Absolutely. From medication schedules to training goals, we partner with you to design a routine that works for your dog.',
+  },
+  {
+    id: 'services-faq-3',
+    question: 'How do bookings work?',
+    answer:
+      'Choose the service that fits best, submit a booking request, and we will confirm availability and next steps right away.',
+  },
+];
+
+const ServicesFaqSection = ({ faqs = [] }) => {
+  const [openItem, setOpenItem] = useState(null);
+  const entries = useMemo(() => (faqs.length > 0 ? faqs : FALLBACK_FAQS), [faqs]);
+
+  useEffect(() => {
+    if (!entries.length) {
+      setOpenItem(null);
+      return;
+    }
+
+    if (!entries.some((item) => (item.id || item.question) === openItem)) {
+      setOpenItem(null);
+    }
+  }, [entries, openItem]);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const toggleItem = (id) => {
+    setOpenItem((current) => (current === id ? null : id));
+  };
+
+  return (
+    <section className="section">
+      <div className="container is-small">
+        <div className="header is-align-center">
+          <h2>Frequently asked questions</h2>
+          <p className="subheading">Answers to help you plan the best care for your dog.</p>
+        </div>
+        <div className="flex_vertical">
+          {entries.map((faq) => {
+            const id = faq.id || faq.question;
+            const isOpen = openItem === id;
+            const summaryText = faq.summary || (faq.answer ? faq.answer.split('\n')[0] : '');
+
+            return (
+              <div key={id} className={`accordion is-transparent${isOpen ? ' w--open' : ''}`}>
+                <button
+                  type="button"
+                  className="accordion_toggle-transparent w-dropdown-toggle"
+                  onClick={() => toggleItem(id)}
+                  aria-expanded={isOpen}
+                >
+                  <div className="accordion_icon w-icon-dropdown-toggle">{faq.question}</div>
+                  {summaryText && (
+                    <div className="paragraph_large margin-bottom_none">{summaryText}</div>
+                  )}
+                </button>
+                {isOpen && (
+                  <div className="accordion_content w-dropdown-list">
+                    <div className="padding_xsmall padding-horizontal_none">
+                      <div className="rich-text w-richtext">
+                        <p>{faq.answer}</p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ServicesFaqSection;

--- a/src/pages/Services/sections/ServicesFeatureSection.jsx
+++ b/src/pages/Services/sections/ServicesFeatureSection.jsx
@@ -1,93 +1,145 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-const ServicesFeatureSection = () => (
-  <section className="section">
+const FALLBACK_IMAGE =
+  'https://cdn.prod.website-files.com/663ae41a035a5092ac55e30d/663ae41a035a5092ac55e325_image_placeholder.svg';
+
+const FALLBACK_ENTRIES = [
+  {
+    id: 'default-service',
+    service_slug: 'walk-and-train',
+    heading: 'This is a normal length heading.',
+    subheading:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.',
+    primary_cta_label: 'Button text',
+    primary_cta_url: '/services/detail',
+    secondary_cta_label: null,
+    secondary_cta_url: null,
+    hero_image_1_url: FALLBACK_IMAGE,
+    hero_image_2_url: FALLBACK_IMAGE,
+  },
+];
+
+const toTitleCase = (value) =>
+  value
+    ? value
+        .split('-')
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join(' ')
+    : 'Service';
+
+const isInternalLink = (url) => typeof url === 'string' && url.startsWith('/');
+
+const CtaLink = ({ cta, variant }) => {
+  if (!cta?.label || !cta?.url) {
+    return null;
+  }
+
+  const className = variant === 'secondary' ? 'button is-secondary w-button' : 'button w-button';
+
+  return isInternalLink(cta.url) ? (
+    <Link to={cta.url} className={className}>
+      {cta.label}
+    </Link>
+  ) : (
+    <a href={cta.url} className={className} target="_blank" rel="noreferrer">
+      {cta.label}
+    </a>
+  );
+};
+
+const ServicesFeatureSection = ({ heroEntries = [] }) => {
+  const entries = heroEntries.length > 0 ? heroEntries : FALLBACK_ENTRIES;
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [heroEntries.length]);
+
+  const activeEntry = useMemo(
+    () => entries[Math.min(activeIndex, entries.length - 1)] ?? entries[0],
+    [entries, activeIndex],
+  );
+
+  const images = useMemo(() => {
+    const sourceImages = [activeEntry?.hero_image_1_url, activeEntry?.hero_image_2_url].filter(Boolean);
+    return sourceImages.length > 0 ? sourceImages : [FALLBACK_IMAGE];
+  }, [activeEntry]);
+
+  if (!activeEntry) {
+    return null;
+  }
+
+  return (
+    <section className="section">
       <div>
         <div className="container">
           <div className="header is-align-center heading-responsive_wrapper">
-            <div className="eyebrow">EYEBROW TEXT</div>
-            <h2 className="heading_h2">This is a normal length heading.</h2>
+            <div className="eyebrow">{toTitleCase(activeEntry.service_slug)}</div>
+            <h2 className="heading_h2">{activeEntry.heading || 'Explore our services'}</h2>
+            {activeEntry.subheading && <p className="subheading">{activeEntry.subheading}</p>}
           </div>
         </div>
         <div className="flex_horizontal flex_vertical gap-large">
           <div className="w-layout-grid grid_2-col tablet-1-col gap-large">
-            <div id="w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc0e-ad47cc0a" className="z-index_2 w-node-a2e67149-e019-c139-b51a-6fbcbc9be87b-df7276e1">
-              <div id="w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc0f-ad47cc0a" className="flex_vertical w-node-a2e67149-e019-c139-b51a-6fbcbc9be87a-df7276e1">
-                <div id="IX-custom-height-1" className="height_100dvh w-node-a2e67149-e019-c139-b51a-6fbcbc9be873-df7276e1"><img width="" height="" alt="" src="https://cdn.prod.website-files.com/663ae41a035a5092ac55e30d/663ae41a035a5092ac55e325_image_placeholder.svg" loading="lazy" className="image image_cover radius_all-0" /></div>
-                <div id="IX-custom-height-2" className="height_100dvh w-node-a2e67149-e019-c139-b51a-6fbcbc9be875-df7276e1"><img width="" height="" alt="" src="https://cdn.prod.website-files.com/663ae41a035a5092ac55e30d/663ae41a035a5092ac55e325_image_placeholder.svg" loading="lazy" className="image image_cover radius_all-0" /></div>
-                <div id="IX-custom-height-3" className="height_100dvh w-node-a2e67149-e019-c139-b51a-6fbcbc9be877-df7276e1"><img width="" height="" alt="" src="https://cdn.prod.website-files.com/663ae41a035a5092ac55e30d/663ae41a035a5092ac55e325_image_placeholder.svg" loading="lazy" className="image image_cover radius_all-0" /></div>
-                <div id="IX-custom-height-4" className="height_100dvh w-node-a2e67149-e019-c139-b51a-6fbcbc9be879-df7276e1"><img width="" height="" alt="" src="https://cdn.prod.website-files.com/663ae41a035a5092ac55e30d/663ae41a035a5092ac55e325_image_placeholder.svg" loading="lazy" className="image image_cover radius_all-0" /></div>
+            <div className="flex_vertical gap-small">
+              {images.map((imageUrl, index) => (
+                <div key={`${activeEntry.id || activeEntry.service_slug}-image-${index}`} className="height_100dvh">
+                  <img
+                    src={imageUrl || FALLBACK_IMAGE}
+                    alt={activeEntry.heading || 'Service visual'}
+                    loading="lazy"
+                    className="image image_cover radius_all-0"
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="position_sticky tablet-stick-bottom z-index_2 backdrop-filter_blur">
+              <div className="flex_vertical gap-xsmall card_body max-width_large">
+                {entries.map((entry, index) => {
+                  const isActive = index === activeIndex;
+                  const entryHeading = entry.heading || toTitleCase(entry.service_slug);
+                  const entryDescription =
+                    entry.subheading ||
+                    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.';
+
+                  return (
+                    <React.Fragment key={entry.id || entry.service_slug || `hero-entry-${index}`}>
+                      <div>
+                        <button
+                          type="button"
+                          className={`custom_change-height-link w-inline-block${isActive ? ' w--current' : ''}`}
+                          onClick={() => setActiveIndex(index)}
+                          aria-pressed={isActive}
+                        ></button>
+                        <div className="eyebrow">{toTitleCase(entry.service_slug)}</div>
+                        <h4>{entryHeading}</h4>
+                        <div className="custom_change-height" style={{ maxHeight: isActive ? '30rem' : 0 }}>
+                          <div className="padding-bottom_xsmall">
+                            <p className="paragraph_large">{entryDescription}</p>
+                            <div className="button-group">
+                              <CtaLink
+                                cta={{ label: entry.primary_cta_label, url: entry.primary_cta_url }}
+                              />
+                              <CtaLink
+                                cta={{ label: entry.secondary_cta_label, url: entry.secondary_cta_url }}
+                                variant="secondary"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      {index < entries.length - 1 && <div className="divider is-secondary"></div>}
+                    </React.Fragment>
+                  );
+                })}
               </div>
             </div>
-            <div id="w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc18-ad47cc0a" className="position_sticky tablet-stick-bottom z-index_2 backdrop-filter_blur w-node-a2e67149-e019-c139-b51a-6fbcbc9be8b4-df7276e1">
-              <div aria-label="image-2" className="flex_vertical gap-xsmall card_body max-width_large">
-                <div>
-                  <button type="button" id="w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc1b-ad47cc0a" aria-label="image-2" className="custom_change-height-link w-node-a2e67149-e019-c139-b51a-6fbcbc9be87c-df7276e1 w-inline-block"></button>
-                  <div className="eyebrow">EYEBROW TEXT</div>
-                  <h4>Medium length headline goes here</h4>
-                  <div aria-label="image-2" className="custom_change-height">
-                    <div className="padding-bottom_xsmall">
-                      <p className="paragraph_large">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.</p>
-                      <div className="button-group">
-                        <Link to="/services/detail" className="button is-secondary w-button">Button text</Link>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className="divider is-secondary"></div>
-                <div>
-                  <button type="button" id="w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc29-ad47cc0a" aria-label="image-2" className="custom_change-height-link w-node-a2e67149-e019-c139-b51a-6fbcbc9be88a-df7276e1 w-inline-block"></button>
-                  <div className="eyebrow">EYEBROW TEXT</div>
-                  <h4>Medium length headline goes here</h4>
-                  <div aria-label="image-2" className="custom_change-height">
-                    <div className="padding-bottom_xsmall">
-                      <p className="paragraph_large">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.</p>
-                      <div className="button-group">
-                        <Link to="/services/detail" className="button is-secondary w-button">Button text</Link>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className="divider is-secondary"></div>
-                <div>
-                  <button type="button" id="w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc37-ad47cc0a" aria-label="image-2" className="custom_change-height-link w-node-a2e67149-e019-c139-b51a-6fbcbc9be898-df7276e1 w-inline-block"></button>
-                  <div className="eyebrow">EYEBROW TEXT</div>
-                  <h4>Medium length headline goes here</h4>
-                  <div aria-label="image-2" className="custom_change-height">
-                    <div className="padding-bottom_xsmall">
-                      <p className="paragraph_large">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.</p>
-                      <div className="button-group">
-                        <Link to="/services/detail" className="button is-secondary w-button">Button text</Link>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className="divider is-secondary"></div>
-                <div>
-                  <button type="button" id="w-node-_8d231ebd-e706-57ae-12d4-0059ad47cc45-ad47cc0a" aria-label="image-2" className="custom_change-height-link w-node-a2e67149-e019-c139-b51a-6fbcbc9be8a6-df7276e1 w-inline-block"></button>
-                  <div className="eyebrow">EYEBROW TEXT</div>
-                  <h4>Medium length headline goes here</h4>
-                  <div aria-label="image-2" className="custom_change-height">
-                    <div className="padding-bottom_xsmall">
-                      <p className="paragraph_large">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.</p>
-                      <div className="button-group">
-                        <Link to="/services/detail" className="button is-secondary w-button">Button text</Link>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="display_none w-embed">
-            <style>{`
-  .custom_change-height-link.w--current ~ .custom_change-height {max-height:30rem;}
-  `}</style>
           </div>
         </div>
       </div>
     </section>
-);
+  );
+};
 
 export default ServicesFeatureSection;

--- a/src/pages/Services/sections/ServicesPricingSection.jsx
+++ b/src/pages/Services/sections/ServicesPricingSection.jsx
@@ -1,167 +1,133 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const ServicesPricingSection = () => (
-  <section className="section is-secondary">
+const FALLBACK_PLANS = [
+  {
+    id: 'walk-and-train',
+    service_slug: 'walk-and-train',
+    title: 'Walk & Train',
+    price: '$0',
+    footnote: 'Always free',
+    description:
+      'Perfect for daily walks and basic training. Flexible, friendly, and tailored to your dog’s needs.\n30-min or custom walks\nGentle, positive training\nPhoto & update after each visit',
+    button_label: 'Book now',
+    button_url: '/contact?service=walk-and-train',
+  },
+  {
+    id: 'day-care',
+    service_slug: 'day-care',
+    title: 'Day Care',
+    price: '$9',
+    footnote: 'Per walk',
+    description:
+      'A safe, playful space for your dog while you’re busy. Half or full days, always supervised and fun.\nSocial play & enrichment\nFlexible drop-off & pick-up\nPersonalized care routines\nDaily photo updates',
+    button_label: 'Reserve',
+    button_url: '/contact?service=day-care',
+  },
+  {
+    id: 'boarding',
+    service_slug: 'boarding',
+    title: 'Boarding',
+    price: '$49',
+    footnote: 'Per night',
+    description:
+      'Overnight stays in a loving home. Your dog enjoys comfort, structure, and plenty of attention.\n24/7 supervision\nDaily walks & playtime\nMedication if needed\nUpdates & photos\nCustom care requests',
+    button_label: 'Request',
+    button_url: '/contact?service=boarding',
+  },
+];
+
+const isInternalLink = (url) => typeof url === 'string' && url.startsWith('/');
+
+const PlanButton = ({ label, url }) => {
+  if (!label || !url) {
+    return null;
+  }
+
+  return isInternalLink(url) ? (
+    <Link to={url} className="button w-inline-block">
+      <div>{label}</div>
+    </Link>
+  ) : (
+    <a href={url} className="button w-inline-block" target="_blank" rel="noreferrer">
+      <div>{label}</div>
+    </a>
+  );
+};
+
+const ServicesPricingSection = ({ carePlans = [] }) => {
+  const plans = carePlans.length > 0 ? carePlans : FALLBACK_PLANS;
+
+  const normalisedPlans = plans.map((plan) => {
+    const descriptionLines = (plan.description || '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    return {
+      id: plan.id || plan.service_slug || plan.title,
+      slug: plan.service_slug || '',
+      title: plan.title || 'Care plan',
+      price: plan.price || '',
+      footnote: plan.footnote || '',
+      summary: descriptionLines[0] || '',
+      features: descriptionLines.slice(1),
+      buttonLabel: plan.button_label,
+      buttonUrl: plan.button_url,
+    };
+  });
+
+  if (normalisedPlans.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="section is-secondary">
       <div className="container">
         <ul className="grid_3-col gap-small padding_none margin-bottom_none w-list-unstyled">
-          <li id="walk-and-train">
-            <div className="card on-secondary">
-              <div className="card_body">
-                <div className="margin-bottom_xsmall">
-                  <div className="w-layout-hflex">
-                    <h4 className="heading_h2 margin-bottom_none">$0</h4>
+          {normalisedPlans.map((plan) => (
+            <li key={plan.id} id={plan.slug || undefined}>
+              <div className="card on-secondary">
+                <div className="card_body">
+                  <div className="margin-bottom_xsmall">
+                    <div className="w-layout-hflex">
+                      {plan.price && <h4 className="heading_h2 margin-bottom_none">{plan.price}</h4>}
+                    </div>
+                    {plan.footnote && <p className="paragraph_small">{plan.footnote}</p>}
                   </div>
-                  <p className="paragraph_small">Always free</p>
-                </div>
-                <div className="divider is-secondary"></div>
-                <div className="margin-top_xsmall margin_bottom-auto">
-                  <h5 className="heading_h3">Walk &amp; Train</h5>
-                  <p>Perfect for daily walks and basic training. Flexible, friendly, and tailored to your dog’s needs.</p><br />
-                  <p></p>
-                </div>
-                <div className="button-group margin-top_xsmall">
-                  <Link to="/contact?service=walk-and-train" className="button w-inline-block">
-                    <div>Book now</div>
-                  </Link>
+                  <div className="divider is-secondary"></div>
+                  <div className="margin-top_xsmall margin_bottom-auto">
+                    <h5 className="heading_h3">{plan.title}</h5>
+                    {plan.summary && <p>{plan.summary}</p>}
+                  </div>
+                  <div className="button-group margin-top_xsmall">
+                    <PlanButton label={plan.buttonLabel} url={plan.buttonUrl} />
+                  </div>
                 </div>
               </div>
-            </div>
-            <ul aria-label="Plan features" className="margin-bottom_none margin-top_small w-list-unstyled">
-              <li className="flex_horizontal gap-xxsmall">
-                <p className="eyebrow">Includes:</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>30-min or custom walks</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Gentle, positive training</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Photo &amp; update after each visit</p>
-              </li>
-            </ul>
-          </li>
-          <li id="day-care">
-            <div className="card on-secondary">
-              <div className="card_body">
-                <div className="margin-bottom_xsmall">
-                  <div className="w-layout-hflex">
-                    <h4 className="heading_h2 margin-bottom_none">$9</h4>
-                  </div>
-                  <p className="paragraph_small">Per walk</p>
-                </div>
-                <div className="divider is-secondary"></div>
-                <div className="margin-top_xsmall margin_bottom-auto">
-                  <h5 className="heading_h3">Day Care</h5>
-                  <p>A safe, playful space for your dog while you’re busy. Half or full days, always supervised and fun.</p>
-                </div>
-                <div className="button-group margin-top_xsmall">
-                  <Link to="/contact?service=day-care" className="button w-inline-block">
-                    <div>Reserve</div>
-                  </Link>
-                </div>
-              </div>
-            </div>
-            <ul aria-label="Plan features" className="margin-bottom_none margin-top_small w-list-unstyled">
-              <li className="flex_horizontal gap-xxsmall">
-                <p className="eyebrow">Includes:</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Social play &amp; enrichment</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Flexible drop-off &amp; pick-up</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Personalized care routines</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Daily photo updates</p>
-              </li>
-            </ul>
-          </li>
-          <li id="boarding">
-            <div className="card on-secondary">
-              <div className="card_body">
-                <div className="margin-bottom_xsmall">
-                  <div className="w-layout-hflex">
-                    <h4 className="heading_h2 margin-bottom_none">$49</h4>
-                  </div>
-                  <p className="paragraph_small">Per night</p>
-                </div>
-                <div className="divider is-secondary"></div>
-                <div className="margin-top_xsmall margin_bottom-auto">
-                  <h5 className="heading_h3">Boarding</h5>
-                  <p>Overnight stays in a loving home. Your dog enjoys comfort, structure, and plenty of attention.</p>
-                </div>
-                <div className="button-group margin-top_xsmall">
-                  <Link to="/contact?service=boarding" className="button w-inline-block">
-                    <div>Request</div>
-                  </Link>
-                </div>
-              </div>
-            </div>
-            <ul aria-label="Plan features" className="margin-bottom_none margin-top_small w-list-unstyled">
-              <li className="flex_horizontal gap-xxsmall">
-                <p className="eyebrow">Includes:</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>24/7 supervision</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Daily walks &amp; playtime</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Medication if needed</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Updates &amp; photos</p>
-              </li>
-              <li className="flex_horizontal gap-xxsmall">
-                <div className="icon is-xsmall is-background"><svg width="100%" height="100%" preserveaspectratio="xMidYMid meet" viewbox="0 0 24 24">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor"></path>
-                  </svg></div>
-                <p>Custom care requests</p>
-              </li>
-            </ul>
-          </li>
+              {plan.features.length > 0 && (
+                <ul aria-label="Plan features" className="margin-bottom_none margin-top_small w-list-unstyled">
+                  <li className="flex_horizontal gap-xxsmall">
+                    <p className="eyebrow">Includes:</p>
+                  </li>
+                  {plan.features.map((feature, featureIndex) => (
+                    <li key={`${plan.id}-feature-${featureIndex}`} className="flex_horizontal gap-xxsmall">
+                      <div className="icon is-xsmall is-background">
+                        <svg width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
+                          <path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41z" fill="currentColor" />
+                        </svg>
+                      </div>
+                      <p>{feature}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
         </ul>
       </div>
     </section>
-);
+  );
+};
 
 export default ServicesPricingSection;

--- a/src/pages/Services/sections/ServicesTestimonialsSection.jsx
+++ b/src/pages/Services/sections/ServicesTestimonialsSection.jsx
@@ -1,13 +1,65 @@
 import React from 'react';
 
-const ServicesTestimonialsSection = () => (
-  <section className="section">
+const FALLBACK_AVATAR =
+  'https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/094b19ee-2c00-4f8f-8331-b47f1c1f2e8a.avif';
+
+const FALLBACK_TESTIMONIALS = [
+  {
+    id: 'alex-rivera',
+    name: 'Alex Rivera',
+    role: 'Dog parent, Amsterdam',
+    quote:
+      'Leaving my energetic husky with Jeroen & Paws was the best decision. I got daily updates, and my dog came home happy, calm, and better behaved than ever.',
+    avatar_url:
+      'https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/094b19ee-2c00-4f8f-8331-b47f1c1f2e8a.avif',
+  },
+  {
+    id: 'taylor-kim',
+    name: 'Taylor Kim',
+    role: 'First-time puppy owner',
+    quote:
+      'The training tips and patient approach made a world of difference for my rescue pup. I felt supported every step of the way.',
+    avatar_url:
+      'https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/40704ce3-ed2d-49cf-a08e-e9d9342031d5.avif',
+  },
+  {
+    id: 'morgan-ellis',
+    name: 'Morgan Ellis',
+    role: 'Frequent traveler',
+    quote:
+      'I trust Jeroen & Paws for boarding whenever I travel. My dog is always excited to visit, and I know he’s in caring, expert hands every time.',
+    avatar_url:
+      'https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/297669ea-6a3b-4f6f-bc0e-37985d9dabf9.avif',
+  },
+  {
+    id: 'jordan-blake',
+    name: 'Jordan Blake',
+    role: 'Busy professional',
+    quote:
+      'Flexible walks and drop-ins fit my schedule perfectly. My dog gets exercise and attention, and I get peace of mind.',
+    avatar_url:
+      'https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/9ab49776-8cef-4755-a926-aa095b3da0d3.avif',
+  },
+];
+
+const ServicesTestimonialsSection = ({ testimonials = [] }) => {
+  const entries = testimonials.length > 0 ? testimonials : FALLBACK_TESTIMONIALS;
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="section">
       <div className="container">
         <div className="w-layout-grid grid_2-col tablet-1-col gap-large">
-          <div id="w-node-_0dc7589f-614c-e2cf-7555-5eed0be05d1f-0be05d1c" className="flex_horizontal flex_vertical is-space-between w-node-_634be294-27c0-98aa-065d-1bda5753a2e2-df7276e1">
+          <div className="flex_horizontal flex_vertical is-space-between">
             <div className="header">
               <h2>What happy dogs (and humans) say</h2>
-              <p className="subheading">Real stories from pet parents who trust us for training, walks, and care. See how our passion and expertise make a difference for every dog.</p>
+              <p className="subheading">
+                Real stories from pet parents who trust us for training, walks, and care. See how our passion and
+                expertise make a difference for every dog.
+              </p>
             </div>
             <div className="w-layout-grid grid_2-col gap-small">
               <div>
@@ -21,58 +73,35 @@ const ServicesTestimonialsSection = () => (
             </div>
           </div>
           <div className="w-layout-grid grid_2-col mobile-l-1-col gap-small">
-            <div id="w-node-d6288141-3e37-a760-1f1f-3f87c261e1bc-0be05d1c" className="card w-node-_634be294-27c0-98aa-065d-1bda5753a2f1-df7276e1">
-              <div className="card_body_small">
-                <div className="flex_horizontal is-y-center gap-xsmall margin-bottom_xsmall">
-                  <div className="avatar"><img width="" height="48" alt="Headshot of a customer with their pet" src="https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/094b19ee-2c00-4f8f-8331-b47f1c1f2e8a.avif" loading="lazy" data-aisg-image-id="094b19ee-2c00-4f8f-8331-b47f1c1f2e8a" className="image_cover" /></div>
-                  <div>
-                    <div className="paragraph_small margin-bottom_none"><strong>Alex Rivera</strong></div>
-                    <div className="paragraph_small">Dog parent, Amsterdam</div>
+            {entries.map((testimonial) => (
+              <div key={testimonial.id || testimonial.name} className="card">
+                <div className="card_body_small">
+                  <div className="flex_horizontal is-y-center gap-xsmall margin-bottom_xsmall">
+                    <div className="avatar">
+                      <img
+                        height="48"
+                        src={testimonial.avatar_url || FALLBACK_AVATAR}
+                        alt={testimonial.name}
+                        loading="lazy"
+                        className="image_cover"
+                      />
+                    </div>
+                    <div>
+                      <div className="paragraph_small margin-bottom_none">
+                        <strong>{testimonial.name}</strong>
+                      </div>
+                      {testimonial.role && <div className="paragraph_small">{testimonial.role}</div>}
+                    </div>
                   </div>
+                  <p className="paragraph_small margin-bottom_none">{testimonial.quote}</p>
                 </div>
-                <p className="paragraph_small margin-bottom_none">Leaving my energetic husky with Jeroen &amp; Paws was the best decision. I got daily updates, and my dog came home happy, calm, and better behaved than ever.</p>
               </div>
-            </div>
-            <div className="card">
-              <div className="card_body_small">
-                <div className="flex_horizontal is-y-center gap-xsmall margin-bottom_xsmall">
-                  <div className="avatar"><img width="" height="48" alt="Headshot of a happy pet owner after training" src="https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/40704ce3-ed2d-49cf-a08e-e9d9342031d5.avif" loading="lazy" data-aisg-image-id="40704ce3-ed2d-49cf-a08e-e9d9342031d5" className="image_cover" /></div>
-                  <div>
-                    <div className="paragraph_small margin-bottom_none"><strong>Taylor Kim</strong></div>
-                    <div className="paragraph_small">First-time puppy owner</div>
-                  </div>
-                </div>
-                <p className="paragraph_small margin-bottom_none">The training tips and patient approach made a world of difference for my rescue pup. I felt supported every step of the way.</p>
-              </div>
-            </div>
-            <div id="w-node-_57b0b48d-fc7d-2a70-7d13-21713b2c2f03-0be05d1c" className="card w-node-_634be294-27c0-98aa-065d-1bda5753a30d-df7276e1">
-              <div className="card_body_small">
-                <div className="flex_horizontal is-y-center gap-xsmall margin-bottom_xsmall">
-                  <div className="avatar"><img width="" height="48" alt="Headshot of a customer with their pet" src="https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/297669ea-6a3b-4f6f-bc0e-37985d9dabf9.avif" loading="lazy" data-aisg-image-id="297669ea-6a3b-4f6f-bc0e-37985d9dabf9" className="image_cover" /></div>
-                  <div>
-                    <div className="paragraph_small margin-bottom_none"><strong>Morgan Ellis</strong></div>
-                    <div className="paragraph_small">Frequent traveler</div>
-                  </div>
-                </div>
-                <p className="paragraph_small margin-bottom_none">I trust Jeroen &amp; Paws for boarding whenever I travel. My dog is always excited to visit, and I know he’s in caring, expert hands every time.</p>
-              </div>
-            </div>
-            <div className="card">
-              <div className="card_body_small">
-                <div className="flex_horizontal is-y-center gap-xsmall margin-bottom_xsmall">
-                  <div className="avatar"><img width="" height="48" alt="Headshot of a customer interacting with their pet" src="https://webflow-prod-assets.s3.amazonaws.com/image-generation-assets/9ab49776-8cef-4755-a926-aa095b3da0d3.avif" loading="lazy" data-aisg-image-id="9ab49776-8cef-4755-a926-aa095b3da0d3" className="image_cover" /></div>
-                  <div>
-                    <div className="paragraph_small margin-bottom_none"><strong>Jordan Blake</strong></div>
-                    <div className="paragraph_small">Busy professional</div>
-                  </div>
-                </div>
-                <p className="paragraph_small margin-bottom_none">Flexible walks and drop-ins fit my schedule perfectly. My dog gets exercise and attention, and I get peace of mind.</p>
-              </div>
-            </div>
+            ))}
           </div>
         </div>
       </div>
     </section>
-);
+  );
+};
 
 export default ServicesTestimonialsSection;


### PR DESCRIPTION
## Summary
- fetch hero, pricing, testimonial, and FAQ records from Supabase for the services page
- render services feature, pricing, testimonials, and CTA sections with dynamic data and graceful fallbacks
- add a services FAQ section that toggles answers and resets state when Supabase data changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfdf4d4bf4832c9a98ec8b6d17ea1d