### PR TITLE
Link mega menu services to dynamic page

### DIFF
--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -57,27 +57,42 @@ const Footer = () => (
             <h2 className="heading_h6 text-color_secondary">Our services</h2>
           </li>
           <li>
-            <Link to="/services#walk-and-train" className="footer_link on-inverse w-inline-block">
+            <Link
+              to="/services?service=walk-and-train#walk-and-train"
+              className="footer_link on-inverse w-inline-block"
+            >
               <div>Walks</div>
             </Link>
           </li>
           <li>
-            <Link to="/services#boarding" className="footer_link on-inverse w-inline-block">
+            <Link
+              to="/services?service=boarding#boarding"
+              className="footer_link on-inverse w-inline-block"
+            >
               <div>Boarding</div>
             </Link>
           </li>
           <li>
-            <Link to="/services#day-care" className="footer_link on-inverse w-inline-block">
+            <Link
+              to="/services?service=day-care#day-care"
+              className="footer_link on-inverse w-inline-block"
+            >
               <div>Daycare</div>
             </Link>
           </li>
           <li>
-            <Link to="/services/detail?plan=training-help" className="footer_link on-inverse w-inline-block">
+            <Link
+              to="/services?service=training-help#training-help"
+              className="footer_link on-inverse w-inline-block"
+            >
               <div>Training</div>
             </Link>
           </li>
           <li>
-            <Link to="/services/detail?plan=custom-solutions" className="footer_link on-inverse w-inline-block">
+            <Link
+              to="/services?service=custom-solutions#custom-solutions"
+              className="footer_link on-inverse w-inline-block"
+            >
               <div>Grooming</div>
             </Link>
           </li>

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -30,7 +30,10 @@ const Navbar = () => (
                             <div className="eyebrow">Dog walking</div>
                             <ul className="mega-nav_list w-list-unstyled">
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=daily-strolls" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=daily-strolls#daily-strolls"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -41,7 +44,10 @@ const Navbar = () => (
                                 </Link>
                               </li>
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=group-adventures" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=group-adventures#group-adventures"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -52,7 +58,10 @@ const Navbar = () => (
                                 </Link>
                               </li>
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=solo-journeys" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=solo-journeys#solo-journeys"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -68,7 +77,10 @@ const Navbar = () => (
                             <div className="eyebrow">Boarding</div>
                             <ul className="mega-nav_list w-list-unstyled">
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=overnight-stays" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=overnight-stays#overnight-stays"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -79,7 +91,10 @@ const Navbar = () => (
                                 </Link>
                               </li>
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=daytime-care" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=daytime-care#daytime-care"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -90,7 +105,10 @@ const Navbar = () => (
                                 </Link>
                               </li>
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=home-check-ins" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=home-check-ins#home-check-ins"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -106,7 +124,10 @@ const Navbar = () => (
                             <div className="eyebrow">Other services</div>
                             <ul className="mega-nav_list w-list-unstyled">
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=pet-transport" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=pet-transport#pet-transport"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -117,7 +138,10 @@ const Navbar = () => (
                                 </Link>
                               </li>
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=training-help" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=training-help#training-help"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>
@@ -128,7 +152,10 @@ const Navbar = () => (
                                 </Link>
                               </li>
                               <li className="margin-bottom_none">
-                                <Link to="/services/detail?plan=custom-solutions" className="mega-nav_link-item w-inline-block">
+                                <Link
+                                  to="/services?service=custom-solutions#custom-solutions"
+                                  className="mega-nav_link-item w-inline-block"
+                                >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
                                     </svg></div>

--- a/src/pages/Detail/sections/DetailHeroSection.jsx
+++ b/src/pages/Detail/sections/DetailHeroSection.jsx
@@ -10,7 +10,12 @@ const DetailHeroSection = () => (
             <p className="subheading">From training to daily walks, boarding, and daycare—your dog’s happiness and well-being are my top priority. Let’s create a routine that fits your life and your pup’s needs.</p>
             <div className="button-group">
               <Link to="/contact?service=meet-and-greet" className="button w-button">Book a Meet &amp; Greet</Link>
-              <Link to="/services#walk-and-train" className="button is-secondary w-button">See Services &amp; Pricing</Link>
+              <Link
+                to="/services?service=walk-and-train#walk-and-train"
+                className="button is-secondary w-button"
+              >
+                See Services &amp; Pricing
+              </Link>
             </div>
           </div>
           <div className="position_relative flex_horizontal">

--- a/src/pages/Services/Services.jsx
+++ b/src/pages/Services/Services.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import ServicesFeatureSection from './sections/ServicesFeatureSection';
 import ServicesPricingSection from './sections/ServicesPricingSection';
 import ServicesTestimonialsSection from './sections/ServicesTestimonialsSection';
@@ -28,6 +29,9 @@ const buildCta = (heroEntry) => {
   };
 };
 
+const normaliseSlug = (value) =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim().toLowerCase() : null;
+
 const Services = () => {
   const [servicesHero, setServicesHero] = useState([]);
   const [carePlans, setCarePlans] = useState([]);
@@ -35,6 +39,15 @@ const Services = () => {
   const [faqs, setFaqs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const { hash, search } = useLocation();
+
+  const activeServiceSlug = useMemo(() => {
+    const params = new URLSearchParams(search);
+    const searchSlug = normaliseSlug(params.get('service') || params.get('plan'));
+    const hashSlug = normaliseSlug(hash?.startsWith('#') ? hash.slice(1) : hash);
+
+    return searchSlug || hashSlug;
+  }, [hash, search]);
 
   useEffect(() => {
     let isMounted = true;
@@ -104,6 +117,18 @@ const Services = () => {
 
   const ctaContent = useMemo(() => buildCta(servicesHero[0]), [servicesHero]);
 
+  useEffect(() => {
+    if (typeof document === 'undefined' || loading || !activeServiceSlug) {
+      return;
+    }
+
+    const target = document.getElementById(activeServiceSlug);
+
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [activeServiceSlug, loading, carePlans.length, servicesHero.length]);
+
   const filteredFaqs = useMemo(
     () =>
       faqs.filter(
@@ -126,7 +151,7 @@ const Services = () => {
           </div>
         </section>
       )}
-      <ServicesFeatureSection heroEntries={servicesHero} />
+      <ServicesFeatureSection heroEntries={servicesHero} activeServiceSlug={activeServiceSlug} />
       <ServicesPricingSection carePlans={carePlans} />
       <ServicesTestimonialsSection testimonials={testimonials} />
       <ServicesFaqSection faqs={filteredFaqs} />

--- a/src/pages/Services/sections/ServicesFeatureSection.jsx
+++ b/src/pages/Services/sections/ServicesFeatureSection.jsx
@@ -12,7 +12,7 @@ const FALLBACK_ENTRIES = [
     subheading:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.',
     primary_cta_label: 'Button text',
-    primary_cta_url: '/services/detail',
+    primary_cta_url: '/services?service=walk-and-train#walk-and-train',
     secondary_cta_label: null,
     secondary_cta_url: null,
     hero_image_1_url: FALLBACK_IMAGE,
@@ -48,13 +48,35 @@ const CtaLink = ({ cta, variant }) => {
   );
 };
 
-const ServicesFeatureSection = ({ heroEntries = [] }) => {
-  const entries = heroEntries.length > 0 ? heroEntries : FALLBACK_ENTRIES;
+const normaliseSlug = (value) =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim().toLowerCase() : '';
+
+const ServicesFeatureSection = ({ heroEntries = [], activeServiceSlug }) => {
+  const entries = useMemo(
+    () => (heroEntries.length > 0 ? heroEntries : FALLBACK_ENTRIES),
+    [heroEntries],
+  );
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
+    if (entries.length === 0) {
+      setActiveIndex(0);
+      return;
+    }
+
+    if (activeServiceSlug) {
+      const targetIndex = entries.findIndex(
+        (entry) => normaliseSlug(entry.service_slug) === normaliseSlug(activeServiceSlug),
+      );
+
+      if (targetIndex !== -1) {
+        setActiveIndex(targetIndex);
+        return;
+      }
+    }
+
     setActiveIndex(0);
-  }, [heroEntries.length]);
+  }, [activeServiceSlug, entries]);
 
   const activeEntry = useMemo(
     () => entries[Math.min(activeIndex, entries.length - 1)] ?? entries[0],
@@ -105,12 +127,13 @@ const ServicesFeatureSection = ({ heroEntries = [] }) => {
 
                   return (
                     <React.Fragment key={entry.id || entry.service_slug || `hero-entry-${index}`}>
-                      <div>
+                      <div id={entry.service_slug || undefined}>
                         <button
                           type="button"
                           className={`custom_change-height-link w-inline-block${isActive ? ' w--current' : ''}`}
                           onClick={() => setActiveIndex(index)}
                           aria-pressed={isActive}
+                          aria-current={isActive ? 'true' : undefined}
                         ></button>
                         <div className="eyebrow">{toTitleCase(entry.service_slug)}</div>
                         <h4>{entryHeading}</h4>


### PR DESCRIPTION
## Summary
- point mega menu and footer service links to the dynamic services page using service slugs
- allow the services page to derive the active service from the URL query or hash and focus the matching entry
- align fallback CTAs and detail hero links with the new services routing

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68dfe86c0dc0832c9fe44c83ae17fec3