### PR TITLE
Add React-controlled dropdown behavior for FAQ and mega nav

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -1,9 +1,51 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-const Navbar = () => (
-<div className="nav is-accent-primary">
-    <div data-duration="400" data-animation="default" data-easing2="ease" data-easing="ease" data-collapse="medium" data-no-scroll="1" className="nav_container w-nav">
+const Navbar = () => {
+  const [isMegaNavOpen, setIsMegaNavOpen] = useState(false);
+  const dropdownRef = useRef(null);
+
+  const closeMegaNav = useCallback(() => {
+    setIsMegaNavOpen(false);
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        closeMegaNav();
+      }
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        closeMegaNav();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeMegaNav]);
+
+  const toggleMegaNav = useCallback(() => {
+    setIsMegaNavOpen((prev) => !prev);
+  }, []);
+
+  return (
+    <div className="nav is-accent-primary">
+      <div
+        data-duration="400"
+        data-animation="default"
+        data-easing2="ease"
+        data-easing="ease"
+        data-collapse="medium"
+        data-no-scroll="1"
+        className="nav_container w-nav"
+      >
       <div className="nav_left">
         <Link to="/" className="nav_logo w-inline-block">
           <div className="nav_logo-icon"><svg width="100%" height="100%" viewbox="0 0 33 33" preserveaspectratio="xMidYMid meet">
@@ -16,13 +58,33 @@ const Navbar = () => (
         <nav aria-label="Primary" className="nav_menu w-nav-menu">
           <ul className="nav_menu-list w-list-unstyled">
             <li className="nav_menu-list-item">
-              <div data-delay="0" data-hover="false" className="nav_dropdown-menu w-dropdown">
-                <div className="nav_link on-accent-primary w-dropdown-toggle">
+              <div
+                ref={dropdownRef}
+                data-delay="0"
+                data-hover="false"
+                className={`nav_dropdown-menu w-dropdown${isMegaNavOpen ? ' w--open' : ''}`}
+              >
+                <div
+                  className={`nav_link on-accent-primary w-dropdown-toggle${isMegaNavOpen ? ' w--open' : ''}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={isMegaNavOpen}
+                  onClick={toggleMegaNav}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      toggleMegaNav();
+                    }
+                  }}
+                >
                   <div>Services</div>
                   <div className="nav-caret w-icon-dropdown-toggle"></div>
                 </div>
-                <nav className="mega-nav_dropdown-list w-dropdown-list">
-                  <div className="mega-nav_dropdown-list-wrapper">
+                <nav
+                  className={`mega-nav_dropdown-list w-dropdown-list${isMegaNavOpen ? ' w--open' : ''}`}
+                  aria-hidden={!isMegaNavOpen}
+                >
+                  <div className={`mega-nav_dropdown-list-wrapper${isMegaNavOpen ? ' w--open' : ''}`}>
                     <ul className="grid_3-col tablet-1-col gap-medium margin-bottom_none w-list-unstyled">
                       <li id="w-node-_61be48fd-08da-7879-1198-67c4146a0181-d66a6ef8" className="w-node-_41e4cb1a-a620-245f-7f74-dc8693dc673e-93dc6729">
                         <div className="w-layout-grid grid_3-col tablet-1-col gap-small">
@@ -33,6 +95,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/daily-strolls"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -47,6 +110,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/group-adventures"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -61,6 +125,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/solo-journeys"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -80,6 +145,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/overnight-stays"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -94,6 +160,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/daytime-care"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -108,6 +175,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/home-check-ins"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -127,6 +195,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/training-help"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -141,6 +210,7 @@ const Navbar = () => (
                                 <Link
                                   to="/services/custom-solutions"
                                   className="mega-nav_link-item w-inline-block"
+                                  onClick={closeMegaNav}
                                 >
                                   <div className="icon is-medium on-accent-primary"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 32 32" fill="currentColor">
                                       <path d="m25.7 9.3l-7-7A.9.9 0 0 0 18 2H8a2.006 2.006 0 0 0-2 2v24a2.006 2.006 0 0 0 2 2h16a2.006 2.006 0 0 0 2-2V10a.9.9 0 0 0-.3-.7M18 4.4l5.6 5.6H18ZM24 28H8V4h8v6a2.006 2.006 0 0 0 2 2h6Z" stroke-linejoin="round"></path>
@@ -156,7 +226,11 @@ const Navbar = () => (
                         </div>
                       </li>
                       <li id="w-node-_61be48fd-08da-7879-1198-67c4146a01f2-d66a6ef8" className="flex_horizontal w-node-_41e4cb1a-a620-245f-7f74-dc8693dc67af-93dc6729">
-                        <Link to="/contact" className="card-link is-inverse flex-child_expand w-inline-block">
+                        <Link
+                          to="/contact"
+                          className="card-link is-inverse flex-child_expand w-inline-block"
+                          onClick={closeMegaNav}
+                        >
                           <div className="card_body">
                             <div className="heading_h3">Plan your dog&#x27;s next adventure</div>
                             <p className="paragraph_small text-color_inverse-secondary">Book a walk, boarding, or custom care today.</p>
@@ -179,17 +253,17 @@ const Navbar = () => (
               </div>
             </li>
             <li className="nav_menu-list-item">
-              <Link to="/about" className="nav_link on-accent-primary w-inline-block">
+              <Link to="/about" className="nav_link on-accent-primary w-inline-block" onClick={closeMegaNav}>
                 <div>About me</div>
               </Link>
             </li>
             <li className="nav_menu-list-item">
-              <Link to="/faq" className="nav_link on-accent-primary w-inline-block">
+              <Link to="/faq" className="nav_link on-accent-primary w-inline-block" onClick={closeMegaNav}>
                 <div>Questions</div>
               </Link>
             </li>
             <li className="nav_menu-list-item">
-              <Link to="/contact" className="nav_link on-accent-primary w-inline-block">
+              <Link to="/contact" className="nav_link on-accent-primary w-inline-block" onClick={closeMegaNav}>
                 <div>Contact</div>
               </Link>
             </li>
@@ -198,7 +272,7 @@ const Navbar = () => (
       </div>
       <div className="nav_right">
         <div className="button-group margin-top_none">
-          <Link to="/contact" className="button on-accent-primary w-inline-block">
+          <Link to="/contact" className="button on-accent-primary w-inline-block" onClick={closeMegaNav}>
             <div className="button_label">Reserve</div>
           </Link>
         </div>
@@ -212,8 +286,9 @@ const Navbar = () => (
             </g>
           </svg></div>
       </div>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Navbar;

--- a/src/pages/FAQ/sections/FaqAccordionSection.jsx
+++ b/src/pages/FAQ/sections/FaqAccordionSection.jsx
@@ -1,68 +1,102 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 
-const FaqAccordionSection = () => (
-  <section data-copilot="true" className="section">
+const faqs = [
+  {
+    question: 'What training methods do you use?',
+    answer:
+      'Every dog is unique, so I use positive, balanced training tailored to your dog’s needs. My approach is gentle, consistent, and always focused on building trust and confidence.',
+  },
+  {
+    question: 'How do walks and visits work?',
+    answer:
+      'Walks and drop-ins are flexible—choose from 30, 45, or 60 minutes. I make sure your dog gets exercise, enrichment, and plenty of attention, whether it’s a quick stroll or a longer adventure.',
+  },
+  {
+    question: 'Is boarding or day care right for my dog?',
+    answer:
+      'Boarding and day care offer a safe, structured, and fun environment. Your dog will enjoy playtime, rest, and personalized care, just like they would at home.',
+  },
+  {
+    question: 'Can you handle special needs or routines?',
+    answer:
+      'Absolutely! I’m experienced with dogs of all ages, breeds, and temperaments—including those with special needs. Just let me know your dog’s routine, and I’ll make sure they feel comfortable and secure.',
+  },
+];
+
+const FaqAccordionSection = () => {
+  const [openIndexes, setOpenIndexes] = useState([]);
+
+  const toggleItem = useCallback((index) => {
+    setOpenIndexes((prev) =>
+      prev.includes(index)
+        ? prev.filter((item) => item !== index)
+        : [...prev, index]
+    );
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event, index) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleItem(index);
+      }
+    },
+    [toggleItem]
+  );
+
+  return (
+    <section data-copilot="true" className="section">
       <div className="container is-small">
-        <div id="w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280" className="header is-align-center w-node-ac52873d-5748-0aed-3d44-55d4506b6066-d19277d5">
+        <div
+          id="w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a282-6d52a280"
+          className="header is-align-center w-node-ac52873d-5748-0aed-3d44-55d4506b6066-d19277d5"
+        >
           <h2>Care for every wagging tail</h2>
-          <p className="subheading">Expert dog training, walks, and loving care—tailored for your best friend.</p>
+          <p className="subheading">
+            Expert dog training, walks, and loving care—tailored for your best friend.
+          </p>
         </div>
-        <div id="w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280" className="flex_vertical w-node-ac52873d-5748-0aed-3d44-55d4506b609d-d19277d5">
-          <div data-delay="0" data-hover="false" className="accordion is-transparent w-dropdown">
-            <div className="accordion_toggle-transparent w-dropdown-toggle">
-              <div className="accordion_icon w-icon-dropdown-toggle"></div>
-              <div className="paragraph_large margin-bottom_none">What training methods do you use?</div>
-            </div>
-            <nav className="accordion_content w-dropdown-list">
-              <div className="padding_xsmall padding-horizontal_none">
-                <div className="rich-text w-richtext">
-                  <p>Every dog is unique, so I use positive, balanced training tailored to your dog’s needs. My approach is gentle, consistent, and always focused on building trust and confidence.</p>
+        <div
+          id="w-node-_1b9fe946-f76f-93ba-3eaa-8c8d6d52a287-6d52a280"
+          className="flex_vertical w-node-ac52873d-5748-0aed-3d44-55d4506b609d-d19277d5"
+        >
+          {faqs.map(({ question, answer }, index) => {
+            const isOpen = openIndexes.includes(index);
+            return (
+              <div
+                key={question}
+                data-delay="0"
+                data-hover="false"
+                className={`accordion is-transparent w-dropdown${isOpen ? ' w--open' : ''}`}
+              >
+                <div
+                  className={`accordion_toggle-transparent w-dropdown-toggle${isOpen ? ' w--open' : ''}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={isOpen}
+                  onClick={() => toggleItem(index)}
+                  onKeyDown={(event) => handleKeyDown(event, index)}
+                >
+                  <div className="accordion_icon w-icon-dropdown-toggle"></div>
+                  <div className="paragraph_large margin-bottom_none">{question}</div>
                 </div>
+                <nav
+                  className={`accordion_content w-dropdown-list${isOpen ? ' w--open' : ''}`}
+                  aria-hidden={!isOpen}
+                >
+                  <div className="padding_xsmall padding-horizontal_none">
+                    <div className="rich-text w-richtext">
+                      <p>{answer}</p>
+                    </div>
+                  </div>
+                </nav>
               </div>
-            </nav>
-          </div>
-          <div data-delay="0" data-hover="false" className="accordion is-transparent w-dropdown">
-            <div className="accordion_toggle-transparent w-dropdown-toggle">
-              <div className="accordion_icon w-icon-dropdown-toggle"></div>
-              <div className="paragraph_large margin-bottom_none">How do walks and visits work?</div>
-            </div>
-            <nav className="accordion_content w-dropdown-list">
-              <div className="padding_xsmall padding-horizontal_none">
-                <div className="rich-text w-richtext">
-                  <p>Walks and drop-ins are flexible—choose from 30, 45, or 60 minutes. I make sure your dog gets exercise, enrichment, and plenty of attention, whether it’s a quick stroll or a longer adventure.</p>
-                </div>
-              </div>
-            </nav>
-          </div>
-          <div data-delay="0" data-hover="false" className="accordion is-transparent w-dropdown">
-            <div className="accordion_toggle-transparent w-dropdown-toggle">
-              <div className="accordion_icon w-icon-dropdown-toggle"></div>
-              <div className="paragraph_large margin-bottom_none">Is boarding or day care right for my dog?</div>
-            </div>
-            <nav className="accordion_content w-dropdown-list">
-              <div className="padding_xsmall padding-horizontal_none">
-                <div className="rich-text w-richtext">
-                  <p>Boarding and day care offer a safe, structured, and fun environment. Your dog will enjoy playtime, rest, and personalized care, just like they would at home.</p>
-                </div>
-              </div>
-            </nav>
-          </div>
-          <div data-delay="0" data-hover="false" className="accordion is-transparent w-dropdown">
-            <div className="accordion_toggle-transparent w-dropdown-toggle">
-              <div className="accordion_icon w-icon-dropdown-toggle"></div>
-              <div className="paragraph_large margin-bottom_none">Can you handle special needs or routines?</div>
-            </div>
-            <nav className="accordion_content w-dropdown-list">
-              <div className="padding_xsmall padding-horizontal_none">
-                <div className="rich-text w-richtext">
-                  <p>Absolutely! I’m experienced with dogs of all ages, breeds, and temperaments—including those with special needs. Just let me know your dog’s routine, and I’ll make sure they feel comfortable and secure.</p>
-                </div>
-              </div>
-            </nav>
-          </div>
+            );
+          })}
         </div>
       </div>
     </section>
-);
+  );
+};
 
 export default FaqAccordionSection;


### PR DESCRIPTION
## Summary
- implement client-side state for the FAQ accordion so items open and close without Webflow.js
- add controlled logic for the Services mega navigation including accessibility improvements and cleanup on outside interactions
- ensure mega navigation links close the dropdown after selection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3cd553154832c96eafa65580cc365