### PR TITLE
Switch booking/availability flow to request flow and simplify modals

### DIFF
--- a/pages/pricing.jsx
+++ b/pages/pricing.jsx
@@ -1,5 +1,0 @@
-import Pricing from "../src/views/Pricing/Pricing";
-
-const PricingPage = () => <Pricing />;
-
-export default PricingPage;

--- a/src/components/Pricing/DynamicPricingSection.jsx
+++ b/src/components/Pricing/DynamicPricingSection.jsx
@@ -1,47 +1,55 @@
 import Link from "next/link";
-import React, { useEffect, useState } from "react";
-import BookingModal from "./BookingModal";
+import React, { useState } from "react";
 import ChatOrFormModal from "./ChatOrFormModal";
 import PricingStyles from "./PricingStyles";
-import AvailabilityPreview from "./AvailabilityPreview";
-import { prefetchAvailability, prefetchAvailabilityBatch } from "./availabilityCache";
+
+const normalizeCtaLabel = (label = "") => {
+  if (!label) return "Send request";
+  if (/check availability/i.test(label)) return "Send request";
+  if (/^book\b/i.test(label)) return label.replace(/^book/i, "Request");
+  return label;
+};
+
+const toKebabCase = (value = "") =>
+  String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
 
 const DynamicPricingSection = ({
   title = "Walking Plans for Every Pup",
   services = [],
   gridClassName = "grid_4-col",
-  defaultCta = "Check availability",
+  defaultCta = "Send request",
 }) => {
-  const [activeService, setActiveService] = useState(null);
   const [ctaChoiceService, setCtaChoiceService] = useState(null);
 
-  useEffect(() => {
-    const batchTargets = services.filter((service) => !service?.ctaHref);
-    if (batchTargets.length) {
-      prefetchAvailabilityBatch(batchTargets);
-    }
-  }, [services]);
-  
   const getCtaLabel = (service) => {
-    if (service.ctaText) return service.ctaText;
-    if (service.duration) return `Book ${service.duration}`;
-    if (service.title) return `Book ${service.title}`;
+    if (service.ctaText) return normalizeCtaLabel(service.ctaText);
+    if (service.duration) return `Request ${service.duration}`;
+    if (service.title) return `Request ${service.title}`;
     return defaultCta;
   };
 
-  const handlePrefetch = (service) => {
-    if (!service?.ctaHref) {
-      prefetchAvailability(service);
-    }
+  const buildRequestService = (service = {}) => {
+    const serviceKey = service.id || service.slug || toKebabCase(service.title) || "custom-request";
+    return {
+      ...service,
+      ctaOptions: {
+        chatUrl: service.ctaOptions?.chatUrl,
+        formUrl: service.ctaOptions?.formUrl || `/contact?service=${serviceKey}`,
+        heading: service.ctaOptions?.heading || `How would you like to request ${service.title || "this service"}?`,
+        description:
+          service.ctaOptions?.description ||
+          "Message us on WhatsApp or send the request form and we will follow up directly.",
+      },
+    };
   };
 
   const handleSelect = (service) => {
-    if (service.ctaOptions) {
-      setCtaChoiceService(service);
-      return;
-    }
     if (service.ctaHref) return;
-    setActiveService(service);
+    setCtaChoiceService(buildRequestService(service));
   };
 
   return (
@@ -60,7 +68,6 @@ const DynamicPricingSection = ({
                   {service.label && <div className="eyebrow">{service.label}</div>}
                   {service.price && <p className="heading_h3">{service.price}</p>}
                   {service.description && <p>{service.description}</p>}
-                  <AvailabilityPreview service={service} />
                 </div>
                 <div className="button-group is-align-center">
                   {service.ctaHref ? (
@@ -83,12 +90,6 @@ const DynamicPricingSection = ({
         </ul>
       </div>
 
-      {activeService && !activeService.ctaHref && (
-        <BookingModal
-          service={activeService}
-          onClose={() => setActiveService(null)}
-        />
-      )}
       {ctaChoiceService?.ctaOptions && (
         <ChatOrFormModal
           service={ctaChoiceService}

--- a/src/components/Pricing/ServiceChooserModal.jsx
+++ b/src/components/Pricing/ServiceChooserModal.jsx
@@ -6,8 +6,8 @@ const ServiceChooserModal = ({
   onSelect,
   onClose,
   title = "Choose a service to book",
-  description = "Pick the option that best fits your companion to continue to availability.",
-  defaultCta = "Check availability",
+  description = "Pick the option that best fits your companion to continue with a request.",
+  defaultCta = "Send request",
 }) => {
   const hasServices = services.length > 0;
 
@@ -16,7 +16,7 @@ const ServiceChooserModal = ({
       <div className="service-chooser">
         <header className="service-chooser__header">
           <div>
-            <p className="eyebrow">Booking</p>
+            <p className="eyebrow">Request</p>
             <h3>{title}</h3>
             <p className="muted">{description}</p>
           </div>

--- a/src/components/Pricing/serviceCtaUtils.js
+++ b/src/components/Pricing/serviceCtaUtils.js
@@ -1,7 +1,7 @@
-export const getServiceCtaLabel = (service, defaultCta = "Check availability") => {
+export const getServiceCtaLabel = (service, defaultCta = "Send request") => {
   if (!service) return defaultCta;
   if (service.ctaText) return service.ctaText;
-  if (service.duration) return `Book ${service.duration}`;
-  if (service.title) return `Book ${service.title}`;
+  if (service.duration) return `Request ${service.duration}`;
+  if (service.title) return `Request ${service.title}`;
   return defaultCta;
 };

--- a/src/components/Pricing/useServiceBooking.js
+++ b/src/components/Pricing/useServiceBooking.js
@@ -1,52 +1,60 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import BookingModal from "./BookingModal";
 import ChatOrFormModal from "./ChatOrFormModal";
 import ServiceChooserModal from "./ServiceChooserModal";
-import { prefetchAvailabilityBatch } from "./availabilityCache";
+
+const toKebabCase = (value = "") =>
+  String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
+const createRequestOptions = (service = {}) => {
+  const serviceKey = service.id || service.slug || toKebabCase(service.title) || "custom-request";
+  const serviceTitle = service.title || "your service";
+
+  return {
+    chatUrl: service.ctaOptions?.chatUrl,
+    formUrl: service.ctaOptions?.formUrl || `/contact?service=${serviceKey}`,
+    heading: service.ctaOptions?.heading || `How would you like to request ${serviceTitle}?`,
+    description:
+      service.ctaOptions?.description ||
+      "Start on WhatsApp for a quick chat, or send a request form and we will follow up.",
+  };
+};
 
 const useServiceBooking = ({
   services = [],
-  defaultCta = "Check availability",
-  chooserTitle = "Choose a service to book",
-  chooserDescription = "Pick the option that best fits your companion to continue to availability.",
+  defaultCta = "Send request",
+  chooserTitle = "Choose a service",
+  chooserDescription = "Pick the option that best fits your companion to continue.",
 } = {}) => {
-  const [activeService, setActiveService] = useState(null);
   const [ctaChoiceService, setCtaChoiceService] = useState(null);
   const [showChooser, setShowChooser] = useState(false);
   const autoOpenedRef = useRef(false);
 
   const handleSelect = useCallback((service) => {
     if (!service) return;
-    if (service.ctaOptions) {
-      setCtaChoiceService(service);
+
+    if (service.ctaHref && typeof window !== "undefined") {
       setShowChooser(false);
+      window.location.href = service.ctaHref;
       return;
     }
-    if (service.ctaHref) {
-      setShowChooser(false);
-      if (typeof window !== "undefined") {
-        window.location.href = service.ctaHref;
-      }
-      return;
-    }
-    setActiveService(service);
+
+    setCtaChoiceService({
+      ...service,
+      ctaOptions: createRequestOptions(service),
+    });
     setShowChooser(false);
   }, []);
-
-  useEffect(() => {
-    const batchTargets = services.filter((service) => !service?.ctaHref);
-    if (batchTargets.length) {
-      prefetchAvailabilityBatch(batchTargets);
-    }
-  }, [services]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (autoOpenedRef.current) return;
 
     const params = new URLSearchParams(window.location.search);
-    if (params.get("booking") !== "1") return;
-
+    if (params.get("booking") !== "1" && params.get("request") !== "1") return;
     if (services.length === 0) return;
 
     const requestedServiceId = params.get("service");
@@ -54,21 +62,23 @@ const useServiceBooking = ({
       ? services.find((service) => service?.id === requestedServiceId)
       : null;
 
+    autoOpenedRef.current = true;
     if (matchingService) {
-      autoOpenedRef.current = true;
       handleSelect(matchingService);
       return;
     }
 
     if (services.length === 1) {
-      autoOpenedRef.current = true;
       handleSelect(services[0]);
+      return;
     }
+
+    setShowChooser(true);
   }, [handleSelect, services]);
 
   const openBooking = useCallback(() => {
     if (services.length === 0) {
-      setShowChooser(true);
+      setCtaChoiceService({ ctaOptions: createRequestOptions({}) });
       return;
     }
 
@@ -90,12 +100,6 @@ const useServiceBooking = ({
           title={chooserTitle}
           description={chooserDescription}
           defaultCta={defaultCta}
-        />
-      )}
-      {activeService && !activeService.ctaHref && (
-        <BookingModal
-          service={activeService}
-          onClose={() => setActiveService(null)}
         />
       )}
       {ctaChoiceService?.ctaOptions && (

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -6,8 +6,7 @@ import { usePrefetchOnIntent } from '../../hooks/usePrefetchOnIntent';
 const Footer = () => {
   const { getLinkProps } = usePrefetchOnIntent([
     '/about',
-    '/pricing',
-    '/contact',
+        '/contact',
     '/faq',
     '/services',
   ]);
@@ -129,15 +128,6 @@ const Footer = () => {
                 {...getLinkProps('/about')}
               >
                 <div>About</div>
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/pricing"
-                className="footer_link on-inverse w-inline-block"
-                {...getLinkProps('/pricing')}
-              >
-                <div>Pricing</div>
               </Link>
             </li>
             <li>

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -13,8 +13,7 @@ const Navbar = () => {
     '/about',
     '/gallery',
     '/faq',
-    '/pricing',
-    '/contact',
+        '/contact',
     '/services',
   ]);
 
@@ -289,16 +288,6 @@ const Navbar = () => {
                 <div>Gallery</div>
               </Link>
             </li>
-            {/* <li className="nav_menu-list-item">
-              <Link
-                href="/pricing"
-                className="nav_link on-accent-primary w-inline-block"
-                onClick={closeAllMenus}
-                {...getLinkProps('/gallery')}
-              >
-                <div>Pricing</div>
-              </Link>
-            </li> */}
             <li className="nav_menu-list-item">
               <Link
                 href="/faq"
@@ -362,13 +351,6 @@ const Navbar = () => {
                 </nav>
               </div>
             </li>
-            {/* <li className ="nav_menu-list-item">
-              <Link href="/booking" className="nav_link on-accent-primary w-inline-block" onClick={closeAllMenus}>
-                  <div>
-                    Booking
-                  </div>
-              </Link>
-            </li> */}
             <li className="nav_menu-list-item">
               <Link
                 href="/contact"

--- a/src/views/Detail/sections/DetailHeroSection.jsx
+++ b/src/views/Detail/sections/DetailHeroSection.jsx
@@ -9,7 +9,7 @@ const DetailHeroSection = () => (
             <h1 className="heading_h1">Expert Dog Care, Tailored For You</h1>
             <p className="subheading">From training to daily walks, boarding, and daycare—your dog’s happiness and well-being are my top priority. Let’s create a routine that fits your life and your pup’s needs.</p>
             <div className="button-group">
-              <Link href="/contact?service=meet-and-greet" className="button w-button">Book a Meet &amp; Greet</Link>
+              <Link href="/contact?service=meet-and-greet" className="button w-button">Request a Meet &amp; Greet</Link>
               <Link
                 href="/services?service=walk-and-train#walk-and-train"
                 className="button is-secondary w-button"

--- a/src/views/Detail/sections/DetailPlansSection.jsx
+++ b/src/views/Detail/sections/DetailPlansSection.jsx
@@ -17,7 +17,7 @@ const DetailPlansSection = () => (
                 <p></p>
               </div>
               <div className="w-layout-hflex button-group is-align-center margin-bottom_xsmall">
-                <Link href="/contact?service=30-minute-walk" className="button w-button">Book a Walk</Link>
+                <Link href="/contact?service=30-minute-walk" className="button w-button">Request a Walk</Link>
               </div>
               <p className="text-color_secondary">Pause or cancel anytime—no worries.</p>
             </div>
@@ -31,7 +31,7 @@ const DetailPlansSection = () => (
                 <p></p>
               </div>
               <div className="w-layout-hflex button-group is-align-center margin-bottom_xsmall">
-                <Link href="/contact?service=60-minute-walk" className="button w-button">Reserve Now</Link>
+                <Link href="/contact?service=60-minute-walk" className="button w-button">Send Request</Link>
               </div>
               <p className="text-color_secondary">Flexible scheduling for busy lives.</p>
             </div>
@@ -45,7 +45,7 @@ const DetailPlansSection = () => (
                 <p></p>
               </div>
               <div className="w-layout-hflex button-group is-align-center margin-bottom_xsmall">
-                <Link href="/contact?service=day-care" className="button w-button">Join Day Care</Link>
+                <Link href="/contact?service=day-care" className="button w-button">Request Day Care</Link>
               </div>
               <p className="text-color_secondary">Your dog’s home away from home.</p>
             </div>

--- a/src/views/Services/Custom-solutions/CustomSolutions.jsx
+++ b/src/views/Services/Custom-solutions/CustomSolutions.jsx
@@ -11,9 +11,9 @@ const CustomSolutions = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose a custom option",
-    chooserDescription: "Pick the tailored service you want before chatting or booking.",
+    chooserDescription: "Pick the tailored service you want before chatting or sending your request.",
   });
 
   useEffect(() => {
@@ -32,7 +32,7 @@ const CustomSolutions = () => {
         durationMinutes: service.duration_minutes || null,
         allowRecurring: service.allow_recurring ?? true,
         allowMultiDay: service.allow_multi_day ?? true,
-        ctaText: "Check availability",
+        ctaText: "Send request",
         ctaOptions: {
           chatUrl: getPreferredChatUrl(),
           formUrl: `/contact?service=${service.slug}`,
@@ -54,7 +54,7 @@ const CustomSolutions = () => {
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Book a Meet &amp; Greet" onClick={openBooking} />
+      <StickyBookingCta label="Request a Meet &amp; Greet" onClick={openBooking} />
       {bookingOverlays}
     </>
   );

--- a/src/views/Services/Custom-solutions/sections/FeatureSection.jsx
+++ b/src/views/Services/Custom-solutions/sections/FeatureSection.jsx
@@ -16,7 +16,7 @@ const FeatureSection = ({ onBook }) => {
             </p>
               <div className="button-group">
               <button type="button" onClick={onBook} className="button w-button">
-                Book a Meet &amp; Greet
+                Request a Meet &amp; Greet
               </button>
               <a href="#services" className="button is-secondary w-button">
                 View services & pricing

--- a/src/views/Services/Custom-solutions/sections/PricingSection.jsx
+++ b/src/views/Services/Custom-solutions/sections/PricingSection.jsx
@@ -24,7 +24,7 @@ const PricingSection = () => {
         durationMinutes: service.duration_minutes || null,
         allowRecurring: service.allow_recurring ?? true,
         allowMultiDay: service.allow_multi_day ?? true,
-        ctaText: "Check availability",
+        ctaText: "Send request",
 
         // Custom-care services always use ctaOptions
         ctaOptions: {
@@ -49,7 +49,7 @@ const PricingSection = () => {
       title="Tailored solutions for every dog"
       services={services}
       gridClassName="grid_4-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );

--- a/src/views/Services/Dailystrolls-service/Dailystrolls.jsx
+++ b/src/views/Services/Dailystrolls-service/Dailystrolls.jsx
@@ -12,9 +12,9 @@ const Dailystrolls = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose your stroll",
-    chooserDescription: "Pick the walk that matches your companion before checking availability.",
+    chooserDescription: "Pick the walk that matches your companion before sending your request.",
   });
 
   useEffect(() => {
@@ -38,7 +38,7 @@ const Dailystrolls = () => {
         allowRecurring: service.allow_recurring ?? true,
         allowMultiDay: service.allow_multi_day ?? true,
         ctaText:
-          service.price === null ? "Build a custom visit" : "Check availability",
+          service.price === null ? "Build a custom visit" : "Send request",
         ...(service.price === null && {
           ctaOptions: {
             chatUrl: getPreferredChatUrl(),
@@ -62,7 +62,7 @@ const Dailystrolls = () => {
       <DailystrollsPricingSection />
       <DailystrollsFaqSection />
       <DailystrollsTestimonialsSection />
-      <StickyBookingCta label="Book a Meet &amp; Greet" />
+      <StickyBookingCta label="Request a Meet &amp; Greet" />
       {bookingOverlays}
     </>
   );

--- a/src/views/Services/Dailystrolls-service/sections/DailystrollsFeatureSection.jsx
+++ b/src/views/Services/Dailystrolls-service/sections/DailystrollsFeatureSection.jsx
@@ -23,7 +23,7 @@ const DailystrollsFeatureSection = ({ onBook }) => {
                 className="button w-button"
                 onClick={onBook}
               >
-                Book your first walk
+                Request your first walk
               </button>
               <a href="#services" className="button is-secondary w-button">
                 View walk plans & pricing

--- a/src/views/Services/Dailystrolls-service/sections/DailystrollsPricingSection.jsx
+++ b/src/views/Services/Dailystrolls-service/sections/DailystrollsPricingSection.jsx
@@ -29,7 +29,7 @@ const DailystrollsPricingSection = () => {
         allowRecurring: service.allow_recurring ?? true,
         allowMultiDay: service.allow_multi_day ?? true,
         ctaText:
-          service.price === null ? "Build a custom visit" : "Check availability",
+          service.price === null ? "Build a custom visit" : "Send request",
         ...(service.price === null && {
           ctaOptions: {
             chatUrl: getPreferredChatUrl(),
@@ -53,7 +53,7 @@ const DailystrollsPricingSection = () => {
       title="Daily stroll options for every companion"
       services={services}
       gridClassName="grid_3-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );

--- a/src/views/Services/Daytime-care/DaytimeCare.jsx
+++ b/src/views/Services/Daytime-care/DaytimeCare.jsx
@@ -12,9 +12,9 @@ const DaytimeCare = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose a daytime care plan",
-    chooserDescription: "Select the schedule that fits your companion before booking.",
+    chooserDescription: "Select the schedule that fits your companion before sending your request.",
   });
 
   useEffect(() => {
@@ -38,7 +38,7 @@ const DaytimeCare = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan tailored care",
+          ctaText: service.price ? "Send request" : "Plan tailored care",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -60,7 +60,7 @@ const DaytimeCare = () => {
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Book a daytime care spot" onClick={openBooking} />
+      <StickyBookingCta label="Request daytime care" onClick={openBooking} />
       {bookingOverlays}
     </>
   );

--- a/src/views/Services/Daytime-care/sections/FeatureSection.jsx
+++ b/src/views/Services/Daytime-care/sections/FeatureSection.jsx
@@ -26,7 +26,7 @@ const FeatureSection = ({ onBook }) => {
                 onClick={onBook}
                 className="button w-button"
               >
-                Book a daytime care spot
+                Request daytime care
               </button>
               <a href="#services" className="button is-secondary w-button">
                 View daytime care plans & pricing

--- a/src/views/Services/Daytime-care/sections/PricingSection.jsx
+++ b/src/views/Services/Daytime-care/sections/PricingSection.jsx
@@ -25,7 +25,7 @@ const PricingSection = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan tailored care",
+          ctaText: service.price ? "Send request" : "Plan tailored care",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -47,7 +47,7 @@ const PricingSection = () => {
       title="Daytime care plans for every companion"
       services={services}
       gridClassName="grid_3-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );

--- a/src/views/Services/Group-adventures/GroupAdventures.jsx
+++ b/src/views/Services/Group-adventures/GroupAdventures.jsx
@@ -12,9 +12,9 @@ const GroupAdventures = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose your adventure",
-    chooserDescription: "Pick the outing that fits your companion before checking availability.",
+    chooserDescription: "Pick the outing that fits your companion before sending your request.",
   });
 
   useEffect(() => {
@@ -38,7 +38,7 @@ const GroupAdventures = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan Custom Adventure",
+          ctaText: service.price ? "Send request" : "Plan Custom Adventure",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -60,7 +60,7 @@ const GroupAdventures = () => {
       <AboutSection />
       <PricingSection />
       <FaqSection />
-      <StickyBookingCta label="Join an adventure" onClick={openBooking} />
+      <StickyBookingCta label="Request an adventure" onClick={openBooking} />
       {bookingOverlays}
     </>
   );

--- a/src/views/Services/Group-adventures/sections/FeatureSection.jsx
+++ b/src/views/Services/Group-adventures/sections/FeatureSection.jsx
@@ -23,7 +23,7 @@ const FeatureSection = ({ onBook }) => {
             </p>
             <div className="button-group">
               <button type="button" onClick={onBook} className="button w-button">
-                Join an adventure
+                Request an adventure
               </button>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing

--- a/src/views/Services/Group-adventures/sections/PricingSection.jsx
+++ b/src/views/Services/Group-adventures/sections/PricingSection.jsx
@@ -25,7 +25,7 @@ const PricingSection = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan Custom Adventure",
+          ctaText: service.price ? "Send request" : "Plan Custom Adventure",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -47,7 +47,7 @@ const PricingSection = () => {
       title="Group Adventure Plans"
       services={services}
       gridClassName="grid_4-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );

--- a/src/views/Services/Home-checkins/HomeCheckins.jsx
+++ b/src/views/Services/Home-checkins/HomeCheckins.jsx
@@ -6,16 +6,15 @@ import TestimonialsSection from './sections/TestimonialsSection';
 import AboutSection from "./sections/AboutSection";
 import useServiceBooking from "../../../components/Pricing/useServiceBooking";
 import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import book from "api/book";
 import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const HomeCheckins = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose your check-in",
-    chooserDescription: "Select a visit length before you continue to booking.",
+    chooserDescription: "Select a visit length before sending your request.",
   });
 
   useEffect(() => {
@@ -39,7 +38,7 @@ const HomeCheckins = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan a custom check-in",
+          ctaText: service.price ? "Send request" : "Plan a custom check-in",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -62,7 +61,7 @@ const HomeCheckins = () => {
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-       <StickyBookingCta label="Book a home check-in" onClick={openBooking} />
+       <StickyBookingCta label="Request a home check-in" onClick={openBooking} />
       {bookingOverlays}
     </>
   );

--- a/src/views/Services/Home-checkins/sections/FeatureSection.jsx
+++ b/src/views/Services/Home-checkins/sections/FeatureSection.jsx
@@ -24,7 +24,7 @@ const FeatureSection = ({ onBook }) => {
             <div className="button-group">
               <button type="button" onClick={onBook} className="button w-button">
 
-                Book a home check-in
+                Request a home check-in
               </button>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing

--- a/src/views/Services/Home-checkins/sections/PricingSection.jsx
+++ b/src/views/Services/Home-checkins/sections/PricingSection.jsx
@@ -25,7 +25,7 @@ const PricingSection = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan a custom check-in",
+          ctaText: service.price ? "Send request" : "Plan a custom check-in",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -47,7 +47,7 @@ const PricingSection = () => {
       title="Home Check-Ins — Flexible Care at Home"
       services={services}
       gridClassName="grid_3-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );

--- a/src/views/Services/Overnight-stays/OvernightStays.jsx
+++ b/src/views/Services/Overnight-stays/OvernightStays.jsx
@@ -12,9 +12,9 @@ const OvernightStays = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose your overnight option",
-    chooserDescription: "Select the stay that fits your dates before booking.",
+    chooserDescription: "Select the stay that fits your dates before sending your request.",
   });
 
   useEffect(() => {
@@ -34,7 +34,7 @@ const OvernightStays = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? false,
-          ctaText: service.price ? "Check availability" : "Plan a tailored stay",
+          ctaText: service.price ? "Send request" : "Plan a tailored stay",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -57,7 +57,7 @@ const OvernightStays = () => {
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Book an overnight stay" onClick={openBooking} />
+      <StickyBookingCta label="Request an overnight stay" onClick={openBooking} />
       {bookingOverlays}
     </>
   );

--- a/src/views/Services/Overnight-stays/sections/FaqSection.jsx
+++ b/src/views/Services/Overnight-stays/sections/FaqSection.jsx
@@ -40,7 +40,7 @@ const FaqSection = () => {
         "Please send their regular food, any medication, and a familiar item such as a blanket or toy. Familiar scents help dogs settle quickly in a new space.",
     },
     {
-      question: "Can I visit your home before booking?",
+      question: "Can I visit your home before requesting care?",
       answer:
         "Of course. A brief meet-and-greet helps your dog become familiar with the space and allows us to discuss routines, expectations, and any questions you may have.",
     },

--- a/src/views/Services/Overnight-stays/sections/FeatureSection.jsx
+++ b/src/views/Services/Overnight-stays/sections/FeatureSection.jsx
@@ -20,7 +20,7 @@ const FeatureSection = ({ onBook }) => {
               company, relaxed routines, outdoor time, and cosy places to rest —
               all supported with attentive supervision and a reassuring,
               lived-in environment where they are never treated as just another
-              booking.
+              request process.
             </p>
             <div className="button-group">
               <button
@@ -28,7 +28,7 @@ const FeatureSection = ({ onBook }) => {
                 onClick={onBook}
                 className="button w-button"
               >
-                Book an overnight stay
+                Request an overnight stay
               </button>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing

--- a/src/views/Services/Overnight-stays/sections/PricingSection.jsx
+++ b/src/views/Services/Overnight-stays/sections/PricingSection.jsx
@@ -21,7 +21,7 @@ const PricingSection = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? false,
-          ctaText: service.price ? "Check availability" : "Plan a tailored stay",
+          ctaText: service.price ? "Send request" : "Plan a tailored stay",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -43,7 +43,7 @@ const PricingSection = () => {
       title="Overnight Stay Options"
       services={services}
       gridClassName="grid_4-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );

--- a/src/views/Services/Solo-journeys/SoloJourneys.jsx
+++ b/src/views/Services/Solo-journeys/SoloJourneys.jsx
@@ -12,7 +12,7 @@ const SoloJourneys = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose your solo journey",
     chooserDescription: "Select the outing you want before scheduling.",
   });
@@ -38,7 +38,7 @@ const SoloJourneys = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan a solo journey",
+          ctaText: service.price ? "Send request" : "Plan a solo journey",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -61,7 +61,7 @@ const SoloJourneys = () => {
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Book a solo journey" onClick={openBooking} />
+      <StickyBookingCta label="Request a solo journey" onClick={openBooking} />
       {bookingOverlays}
     </>
   );

--- a/src/views/Services/Solo-journeys/sections/FeatureSection.jsx
+++ b/src/views/Services/Solo-journeys/sections/FeatureSection.jsx
@@ -27,7 +27,7 @@ const FeatureSection = ({ onBook }) => {
                 onClick={onBook}
                 className="button w-button"
               >
-                Book a solo journey
+                Request a solo journey
               </button>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing

--- a/src/views/Services/Solo-journeys/sections/PricingSection.jsx
+++ b/src/views/Services/Solo-journeys/sections/PricingSection.jsx
@@ -25,7 +25,7 @@ const SoloJourneyPricingSection = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan a solo journey",
+          ctaText: service.price ? "Send request" : "Plan a solo journey",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -47,7 +47,7 @@ const SoloJourneyPricingSection = () => {
       title="Solo Journey Plans"
       services={services}
       gridClassName="grid_3-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );

--- a/src/views/Services/Training-help/TrainingHelp.jsx
+++ b/src/views/Services/Training-help/TrainingHelp.jsx
@@ -11,7 +11,7 @@ const TrainingHelp = () => {
   const [services, setServices] = useState([]);
   const { openBooking, bookingOverlays } = useServiceBooking({
     services,
-    defaultCta: "Check availability",
+    defaultCta: "Send request",
     chooserTitle: "Choose your training session",
     chooserDescription: "Pick the focus you want before scheduling.",
   });
@@ -37,7 +37,7 @@ const TrainingHelp = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan a tailored session",
+          ctaText: service.price ? "Send request" : "Plan a tailored session",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),

--- a/src/views/Services/Training-help/sections/PricingSection.jsx
+++ b/src/views/Services/Training-help/sections/PricingSection.jsx
@@ -25,7 +25,7 @@ const PricingSection = () => {
           durationMinutes: service.duration_minutes || null,
           allowRecurring: service.allow_recurring ?? true,
           allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Check availability" : "Plan a tailored session",
+          ctaText: service.price ? "Send request" : "Plan a tailored session",
           ...(service.price === null && {
             ctaOptions: {
               chatUrl: getPreferredChatUrl(),
@@ -47,7 +47,7 @@ const PricingSection = () => {
       title="Training Help — Session Options"
       services={services}
       gridClassName="grid_4-col"
-      defaultCta="Check availability"
+      defaultCta="Send request"
     />
     </section>
   );


### PR DESCRIPTION
### Motivation
- Move the site from immediate "booking / check availability" flows to a request-first workflow by standardising CTAs and copy to "Send request" / "Request".
- Simplify the UI by consolidating modal flows into a unified chat-or-form modal and remove the old availability booking modal and related prefetching.
- Remove the now-unused static pricing page and related navigation entry.

### Description
- Updated global CTA wording and labels by changing defaults from `"Check availability"` / `"Book"` to `"Send request"` / `"Request"` across service views and sticky CTAs.
- Refactored booking logic: removed `BookingModal`, `AvailabilityPreview`, and availability prefetch usage and replaced selection flow to build `ctaOptions` (form/chat URLs and headings) and open `ChatOrFormModal` instead, using helper functions `createRequestOptions`, `toKebabCase` and `normalizeCtaLabel` where appropriate.
- Reworked `useServiceBooking` to simplify selection, navigate to `service.ctaHref` when provided, support `request=1` URL auto-open behavior, and return `bookingOverlays` that only render `ServiceChooserModal` and `ChatOrFormModal`.
- Deleted the `pages/pricing.jsx` page and removed `/pricing` links from `Navbar` and `Footer`.

### Testing
- Built the client bundle with `yarn build` and the build completed successfully.
- Ran the test suite with `yarn test` and all automated tests passed.
- Ran linting with `yarn lint` to verify formatting and static checks and there were no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea903f64e4832c8ced0197e392fc48)