### PR TITLE
Remove booking/calendar UI from service pages

### DIFF
--- a/src/views/Services/Custom-solutions/CustomSolutions.jsx
+++ b/src/views/Services/Custom-solutions/CustomSolutions.jsx
@@ -1,61 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FaqSection from './sections/FaqSection';
 import FeatureSection from './sections/FeatureSection';
 import PricingSection from './sections/PricingSection';
 import TestimonialsSection from './sections/TestimonialsSection';
-import useServiceBooking from "../../../components/Pricing/useServiceBooking";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const CustomSolutions = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose a custom option",
-    chooserDescription: "Pick the tailored service you want before chatting or sending your request.",
-  });
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/services?category=Custom Care`);
-      const data = await res.json();
-
-      const mapped = (data.services || []).map((service) => ({
-        id: service.slug,
-        title: service.title,
-        description: service.description || "",
-        category: service.category || "Custom Care",
-        price: service.price || "Custom Quote",
-        label: service.duration_minutes ? "Multi-Session" : "Tailored Care",
-        duration: service.duration_minutes ? "Multi-Session" : "Custom Plan",
-        durationMinutes: service.duration_minutes || null,
-        allowRecurring: service.allow_recurring ?? true,
-        allowMultiDay: service.allow_multi_day ?? true,
-        ctaText: "Send request",
-        ctaOptions: {
-          chatUrl: getPreferredChatUrl(),
-          formUrl: `/contact?service=${service.slug}`,
-          heading: `Tell me more about "${service.title}"`,
-          description:
-            "Start a chat for quick questions, or send a detailed request through the form.",
-        },
-      }));
-
-      setServices(mapped);
-    }
-
-    load();
-  }, []);
-
   return (
     <>
-      <FeatureSection onBook={openBooking} />
+      <FeatureSection />
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Request a Meet &amp; Greet" onClick={openBooking} />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Custom-solutions/sections/FeatureSection.jsx
+++ b/src/views/Services/Custom-solutions/sections/FeatureSection.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const FeatureSection = ({ onBook }) => {
+const FeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -15,9 +15,9 @@ const FeatureSection = ({ onBook }) => {
               From training to daily walks, day care, and boarding — your dog’s comfort and happiness always come first. Together, we’ll create a personalised care plan that suits your lifestyle and supports your dog’s unique needs.
             </p>
               <div className="button-group">
-              <button type="button" onClick={onBook} className="button w-button">
+              <a href="/contact" className="button w-button">
                 Request a Meet &amp; Greet
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View services & pricing
               </a>

--- a/src/views/Services/Dailystrolls-service/Dailystrolls.jsx
+++ b/src/views/Services/Dailystrolls-service/Dailystrolls.jsx
@@ -1,69 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import DailystrollsFaqSection from "./sections/DailystrollsFaqSection";
 import DailystrollsFeatureSection from "./sections/DailystrollsFeatureSection";
 import DailystrollsPricingSection from "./sections/DailystrollsPricingSection";
 import DailystrollsTestimonialsSection from "./sections/DailystrollsTestimonialsSection";
 import AboutSection from "./sections/AboutSection";
-import useServiceBooking from "../../../components/Pricing/useServiceBooking";
-import StickyBookingCta from "../../../components/StickyBookingCta";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
 
 const Dailystrolls = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose your stroll",
-    chooserDescription: "Pick the walk that matches your companion before sending your request.",
-  });
-
-  useEffect(() => {
-    async function loadServices() {
-      const res = await fetch(`/api/services?category=Daily Strolls`);
-      const data = await res.json();
-
-      const mapped = (data.services || []).map((service) => ({
-        id: service.slug,
-        title: service.title,
-        description: service.description || "",
-        category: service.category || "Daily Strolls",
-        price: service.price || "Tailored",
-        label: service.duration_minutes
-          ? `${service.duration_minutes}-Min Visit`
-          : "Tailored Visit",
-        duration: service.duration_minutes
-          ? `${service.duration_minutes}-Min Visit`
-          : "Custom Plan",
-        durationMinutes: service.duration_minutes || null,
-        allowRecurring: service.allow_recurring ?? true,
-        allowMultiDay: service.allow_multi_day ?? true,
-        ctaText:
-          service.price === null ? "Build a custom visit" : "Send request",
-        ...(service.price === null && {
-          ctaOptions: {
-            chatUrl: getPreferredChatUrl(),
-            formUrl: `/contact?service=${service.slug}`,
-            heading: "How would you like to plan your tailored stroll?",
-            description: "Tell us what you have in mind — WhatsApp or form.",
-          },
-        }),
-      }));
-
-      setServices(mapped);
-    }
-
-    loadServices();
-  }, []);
-
   return (
     <>
-      <DailystrollsFeatureSection onBook={openBooking} />
+      <DailystrollsFeatureSection />
       <AboutSection />
       <DailystrollsPricingSection />
       <DailystrollsFaqSection />
       <DailystrollsTestimonialsSection />
-      <StickyBookingCta label="Request a Meet &amp; Greet" />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Dailystrolls-service/sections/DailystrollsFeatureSection.jsx
+++ b/src/views/Services/Dailystrolls-service/sections/DailystrollsFeatureSection.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const DailystrollsFeatureSection = ({ onBook }) => {
+const DailystrollsFeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -18,13 +18,9 @@ const DailystrollsFeatureSection = ({ onBook }) => {
               the day.
             </p>
             <div className="button-group">
-              <button
-                type="button"
-                className="button w-button"
-                onClick={onBook}
-              >
+              <a href="/contact" className="button w-button">
                 Request your first walk
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View walk plans & pricing
               </a>

--- a/src/views/Services/Daytime-care/DaytimeCare.jsx
+++ b/src/views/Services/Daytime-care/DaytimeCare.jsx
@@ -1,67 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FaqSection from './sections/FaqSection';
 import FeatureSection from './sections/FeatureSection';
 import PricingSection from './sections/PricingSection';
 import TestimonialsSection from './sections/TestimonialsSection';
 import AboutSection from "./sections/AboutSection";
-import useServiceBooking from "../../../components/Pricing/useServiceBooking";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const DaytimeCare = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose a daytime care plan",
-    chooserDescription: "Select the schedule that fits your companion before sending your request.",
-  });
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/services?category=Daytime Care`);
-      const data = await res.json();
-
-      setServices(
-        (data.services || []).map((service) => ({
-          id: service.slug,
-          title: service.title,
-          description: service.description || "",
-          category: service.category || "Daytime Care",
-          price: service.price || "Tailored",
-          label: service.duration_minutes
-            ? `${service.duration_minutes / 60}-Hour Stay`
-            : "Flexible Schedule",
-          duration: service.duration_minutes
-            ? `${service.duration_minutes / 60}-Hour Stay`
-            : "Custom Schedule",
-          durationMinutes: service.duration_minutes || null,
-          allowRecurring: service.allow_recurring ?? true,
-          allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Send request" : "Plan tailored care",
-          ...(service.price === null && {
-            ctaOptions: {
-              chatUrl: getPreferredChatUrl(),
-              formUrl: `/contact?service=${service.slug}`,
-              heading: "How would you like to plan tailored daytime care?",
-              description: "WhatsApp or submit a request form.",
-            },
-          }),
-        }))
-      );
-    }
-
-    load();
-  }, []);
   return (
     <>
-      <FeatureSection onBook={openBooking}/>
+      <FeatureSection />
       <AboutSection />
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Request daytime care" onClick={openBooking} />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Daytime-care/sections/FeatureSection.jsx
+++ b/src/views/Services/Daytime-care/sections/FeatureSection.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const FeatureSection = ({ onBook }) => {
+const FeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -21,13 +21,9 @@ const FeatureSection = ({ onBook }) => {
               ease.
             </p>
             <div className="button-group">
-              <button
-                type="button"
-                onClick={onBook}
-                className="button w-button"
-              >
+              <a href="/contact" className="button w-button">
                 Request daytime care
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View daytime care plans & pricing
               </a>

--- a/src/views/Services/Group-adventures/GroupAdventures.jsx
+++ b/src/views/Services/Group-adventures/GroupAdventures.jsx
@@ -1,67 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FaqSection from './sections/FaqSection';
 import FeatureSection from './sections/FeatureSection';
 import PricingSection from './sections/PricingSection';
-import TestimonialsSection from './sections/TestimonialsSection';
 import AboutSection from "./sections/AboutSection";
-import useServiceBooking from "../../../components/Pricing/useServiceBooking";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const GroupAdventures = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose your adventure",
-    chooserDescription: "Pick the outing that fits your companion before sending your request.",
-  });
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/services?category=Group Adventures`);
-      const data = await res.json();
-
-      setServices(
-        (data.services || []).map((service) => ({
-          id: service.slug,
-          title: service.title,
-          description: service.description || "",
-          category: service.category || "Group Adventures",
-          price: service.price || "Custom",
-          label: service.duration_minutes
-            ? `${service.duration_minutes / 60}-Hour Adventure`
-            : "Custom Adventure",
-          duration: service.duration_minutes
-            ? `${service.duration_minutes / 60}-Hour Adventure`
-            : "Custom Adventure",
-          durationMinutes: service.duration_minutes || null,
-          allowRecurring: service.allow_recurring ?? true,
-          allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Send request" : "Plan Custom Adventure",
-          ...(service.price === null && {
-            ctaOptions: {
-              chatUrl: getPreferredChatUrl(),
-              formUrl: `/contact?service=${service.slug}`,
-              heading: "How would you like to plan your custom adventure?",
-              description: "Tell us timing, walk frequency or needs.",
-            },
-          }),
-        }))
-      );
-    }
-
-    load();
-  }, []);
-
   return (
     <>
-      <FeatureSection onBook={openBooking}/>
+      <FeatureSection />
       <AboutSection />
       <PricingSection />
       <FaqSection />
-      <StickyBookingCta label="Request an adventure" onClick={openBooking} />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Group-adventures/sections/FeatureSection.jsx
+++ b/src/views/Services/Group-adventures/sections/FeatureSection.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const FeatureSection = ({ onBook }) => {
+const FeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -22,9 +22,9 @@ const FeatureSection = ({ onBook }) => {
               throughout.
             </p>
             <div className="button-group">
-              <button type="button" onClick={onBook} className="button w-button">
+              <a href="/contact" className="button w-button">
                 Request an adventure
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing
               </a>

--- a/src/views/Services/Home-checkins/HomeCheckins.jsx
+++ b/src/views/Services/Home-checkins/HomeCheckins.jsx
@@ -1,68 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FaqSection from './sections/FaqSection';
 import FeatureSection from './sections/FeatureSection';
 import PricingSection from './sections/PricingSection';
 import TestimonialsSection from './sections/TestimonialsSection';
 import AboutSection from "./sections/AboutSection";
-import useServiceBooking from "../../../components/Pricing/useServiceBooking";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const HomeCheckins = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose your check-in",
-    chooserDescription: "Select a visit length before sending your request.",
-  });
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/services?category=Home Visits`);
-      const data = await res.json();
-
-      setServices(
-        (data.services || []).map((service) => ({
-          id: service.slug,
-          title: service.title,
-          description: service.description || "",
-          category: service.category || "Home Visits",
-          price: service.price || "Tailored",
-          label: service.duration_minutes
-            ? `${service.duration_minutes}-Min Visit`
-            : "Flexible Timing",
-          duration: service.duration_minutes
-            ? `${service.duration_minutes}-Min Visit`
-            : "Custom Plan",
-          durationMinutes: service.duration_minutes || null,
-          allowRecurring: service.allow_recurring ?? true,
-          allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Send request" : "Plan a custom check-in",
-          ...(service.price === null && {
-            ctaOptions: {
-              chatUrl: getPreferredChatUrl(),
-              formUrl: `/contact?service=${service.slug}`,
-              heading: "How would you like to plan your custom check-in?",
-              description: "Share timings or special instructions.",
-            },
-          }),
-        }))
-      );
-    }
-
-    load();
-  }, []);
-
   return (
     <>
-      <FeatureSection onBook={openBooking}/>
+      <FeatureSection />
       <AboutSection />
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-       <StickyBookingCta label="Request a home check-in" onClick={openBooking} />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Home-checkins/sections/FeatureSection.jsx
+++ b/src/views/Services/Home-checkins/sections/FeatureSection.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const FeatureSection = ({ onBook }) => {
+const FeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -22,10 +22,10 @@ const FeatureSection = ({ onBook }) => {
               while you are away.
             </p>
             <div className="button-group">
-              <button type="button" onClick={onBook} className="button w-button">
+              <a href="/contact" className="button w-button">
 
                 Request a home check-in
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing
               </a>

--- a/src/views/Services/Overnight-stays/OvernightStays.jsx
+++ b/src/views/Services/Overnight-stays/OvernightStays.jsx
@@ -1,64 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FaqSection from './sections/FaqSection';
 import FeatureSection from './sections/FeatureSection';
 import PricingSection from './sections/PricingSection';
 import TestimonialsSection from './sections/TestimonialsSection';
 import AboutSection from "./sections/AboutSection";
-import useServiceBooking from "../../../components/Pricing/useServiceBooking";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const OvernightStays = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose your overnight option",
-    chooserDescription: "Select the stay that fits your dates before sending your request.",
-  });
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/services?category=Overnight Support`);
-      const data = await res.json();
-
-      setServices(
-        (data.services || []).map((service) => ({
-          id: service.slug,
-          title: service.title,
-          description: service.description || "",
-          category: service.category || "Overnight Support",
-          price: service.price || "Tailored",
-          label: service.duration_minutes === 1440 ? "Boarding — 24 hrs" : "Custom duration",
-          duration: service.duration_minutes === 1440 ? "Overnight Stay" : "Custom Duration",
-          durationMinutes: service.duration_minutes || null,
-          allowRecurring: service.allow_recurring ?? true,
-          allowMultiDay: service.allow_multi_day ?? false,
-          ctaText: service.price ? "Send request" : "Plan a tailored stay",
-          ...(service.price === null && {
-            ctaOptions: {
-              chatUrl: getPreferredChatUrl(),
-              formUrl: `/contact?service=${service.slug}`,
-              heading: "How should we plan your custom stay?",
-              description: "Discuss dates via WhatsApp or request form.",
-            },
-          }),
-        }))
-      );
-    }
-
-    load();
-  }, []);
-
   return (
     <>
-      <FeatureSection onBook={openBooking}/>
+      <FeatureSection />
       <AboutSection />
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Request an overnight stay" onClick={openBooking} />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Overnight-stays/sections/FeatureSection.jsx
+++ b/src/views/Services/Overnight-stays/sections/FeatureSection.jsx
@@ -1,7 +1,6 @@
 import React from "react";
-import Link from "next/link";
 
-const FeatureSection = ({ onBook }) => {
+const FeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -23,13 +22,9 @@ const FeatureSection = ({ onBook }) => {
               request process.
             </p>
             <div className="button-group">
-              <button
-                type="button"
-                onClick={onBook}
-                className="button w-button"
-              >
+              <a href="/contact" className="button w-button">
                 Request an overnight stay
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing
               </a>

--- a/src/views/Services/Solo-journeys/SoloJourneys.jsx
+++ b/src/views/Services/Solo-journeys/SoloJourneys.jsx
@@ -1,68 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FaqSection from './sections/FaqSection';
 import FeatureSection from './sections/FeatureSection';
 import PricingSection from './sections/PricingSection';
 import TestimonialsSection from './sections/TestimonialsSection';
 import AboutSection from "./sections/AboutSection";
-import useServiceBooking from "../../../components/Pricing/useServiceBooking.js";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const SoloJourneys = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose your solo journey",
-    chooserDescription: "Select the outing you want before scheduling.",
-  });
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/services?category=Solo Journeys`);
-      const data = await res.json();
-
-      setServices(
-        (data.services || []).map((service) => ({
-          id: service.slug,
-          title: service.title,
-          description: service.description || "",
-          category: service.category || "Solo Journeys",
-          price: service.price || "Tailored",
-          label: service.duration_minutes
-            ? `${service.duration_minutes / 60}-Hour Journey`
-            : "Flexible Hours",
-          duration: service.duration_minutes
-            ? `${service.duration_minutes / 60}-Hour Journey`
-            : "Custom Journey",
-          durationMinutes: service.duration_minutes || null,
-          allowRecurring: service.allow_recurring ?? true,
-          allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Send request" : "Plan a solo journey",
-          ...(service.price === null && {
-            ctaOptions: {
-              chatUrl: getPreferredChatUrl(),
-              formUrl: `/contact?service=${service.slug}`,
-              heading: "How should we plan your custom stay?",
-              description: "WhatsApp to discuss dates or request form.",
-            },
-          }),
-        }))
-      );
-    }
-
-    load();
-  }, []);
-
   return (
     <>
-      <FeatureSection onBook={openBooking}/>
+      <FeatureSection />
       <AboutSection />
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Request a solo journey" onClick={openBooking} />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Solo-journeys/sections/FeatureSection.jsx
+++ b/src/views/Services/Solo-journeys/sections/FeatureSection.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const FeatureSection = ({ onBook }) => {
+const FeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -22,13 +22,9 @@ const FeatureSection = ({ onBook }) => {
               you can share in their experience.
             </p>
             <div className="button-group">
-              <button
-                type="button"
-                onClick={onBook}
-                className="button w-button"
-              >
+              <a href="/contact" className="button w-button">
                 Request a solo journey
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing
               </a>

--- a/src/views/Services/Training-help/TrainingHelp.jsx
+++ b/src/views/Services/Training-help/TrainingHelp.jsx
@@ -1,66 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FaqSection from './sections/FaqSection';
 import FeatureSection from './sections/FeatureSection';
 import PricingSection from './sections/PricingSection';
 import TestimonialsSection from './sections/TestimonialsSection';
-import useServiceBooking from "../../../components/Pricing/useServiceBooking";
-import { getPreferredChatUrl } from "../../../utils/chatLinks";
-import StickyBookingCta from "../../../components/StickyBookingCta";
 
 const TrainingHelp = () => {
-  const [services, setServices] = useState([]);
-  const { openBooking, bookingOverlays } = useServiceBooking({
-    services,
-    defaultCta: "Send request",
-    chooserTitle: "Choose your training session",
-    chooserDescription: "Pick the focus you want before scheduling.",
-  });
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/services?category=Training`);
-      const data = await res.json();
-
-      setServices(
-        (data.services || []).map((service) => ({
-          id: service.slug,
-          title: service.title,
-          description: service.description || "",
-          category: service.category || "Training",
-          price: service.price || "Tailored",
-          label: service.duration_minutes
-            ? `${service.duration_minutes}-Min Session`
-            : "Flexible Duration",
-          duration: service.duration_minutes
-            ? `${service.duration_minutes}-Min Session`
-            : "Custom Plan",
-          durationMinutes: service.duration_minutes || null,
-          allowRecurring: service.allow_recurring ?? true,
-          allowMultiDay: service.allow_multi_day ?? true,
-          ctaText: service.price ? "Send request" : "Plan a tailored session",
-          ...(service.price === null && {
-            ctaOptions: {
-              chatUrl: getPreferredChatUrl(),
-              formUrl: `/contact?service=${service.slug}`,
-              heading: "How should we plan your tailored session?",
-              description: "WhatsApp or submit a detailed request.",
-            },
-          }),
-        }))
-      );
-    }
-
-    load();
-  }, []);
-
   return (
     <>
-      <FeatureSection onBook={openBooking}/>
+      <FeatureSection />
       <PricingSection />
       <FaqSection />
       <TestimonialsSection />
-      <StickyBookingCta label="Plan a training" onClick={openBooking} />
-      {bookingOverlays}
     </>
   );
 };

--- a/src/views/Services/Training-help/sections/FeatureSection.jsx
+++ b/src/views/Services/Training-help/sections/FeatureSection.jsx
@@ -1,7 +1,6 @@
 import React from "react";
-import Link from "next/link";
 
-const FeatureSection = ({ onBook }) => {
+const FeatureSection = () => {
   return (
     <header className="section" data-sticky-anchor="true">
       <div className="container">
@@ -21,9 +20,9 @@ const FeatureSection = ({ onBook }) => {
               progress through simple routines you can continue with ease.
             </p>
             <div className="button-group">
-              <button type="button" onClick={onBook} className="button w-button">
+              <a href="/contact" className="button w-button">
                 Plan a training
-              </button>
+              </a>
               <a href="#services" className="button is-secondary w-button">
                 View services and pricing
               </a>


### PR DESCRIPTION
### Motivation
- The site now uses hardcoded service pages so the interactive booking/calendar flows are no longer required on service detail pages.
- Remove client-side booking hooks and calendar entry points to simplify the UI and direct users to the contact form for requests.

### Description
- Removed `useServiceBooking` usage and `StickyBookingCta` wiring from service containers and stopped fetching/mapping services in those pages, leaving them to render their static sections only (feature/about/pricing/faq/testimonials). 
- Replaced hero CTA buttons that previously invoked booking handlers with direct links to `/contact` so CTAs open the contact form instead of booking modals or calendars. 
- Removed references to calendar/booking helper imports (`getPreferredChatUrl`, `useServiceBooking`, `StickyBookingCta`) from the modified files. 
- Changes applied across the service pages and hero components (16 files updated, e.g. `src/views/Services/*` and their `sections/FeatureSection.jsx` files). 

### Testing
- `npm run build` completed successfully and static pages were generated without runtime build errors. 
- `npm run lint` / `npx next lint` could not be run cleanly in this environment due to the repository ESLint/Next configuration returning project-directory/config errors. 
- Running `npx eslint` on modified files failed in this environment due to the ESLint config format in use (ESLint v9 message about `eslint.config.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed33cf45cc832ca90eceab6637c193)