### PR TITLE
Redesign services cards to showcase layout using home slider images

### DIFF
--- a/src/assets/css/jeroen-paws.css
+++ b/src/assets/css/jeroen-paws.css
@@ -7694,3 +7694,75 @@ html {
 .stats-background {
   background-color: var(--ai-gen-82921b10-4b39-48f0-b346-808cf4903d29-1759229239308---core-color-tint--accent-primary-a90)
 }
+.services-grid--showcase {
+  gap: 1.75rem;
+}
+
+.services-showcase-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #dbe7df;
+  border-radius: 1.5rem;
+  background: #f9fbf8;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.services-showcase-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 45px -30px rgba(20, 46, 35, 0.45);
+}
+
+.services-showcase-media {
+  position: relative;
+  min-height: 240px;
+}
+
+.services-showcase-price {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 2;
+  background: #ffffff;
+  color: #1a2d24;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 1rem;
+  padding: 0.6rem 1rem;
+  box-shadow: 0 8px 20px rgba(17, 24, 39, 0.18);
+}
+
+.services-showcase-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.25rem;
+  flex: 1;
+}
+
+.services-showcase-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.services-showcase-tag {
+  border-radius: 999px;
+  background: #e8f0eb;
+  color: #355849;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+}
+
+.services-showcase-footer {
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px solid #dce7df;
+}
+
+@media (max-width: 767px) {
+  .services-showcase-media {
+    min-height: 210px;
+  }
+}

--- a/src/views/Services/Services.jsx
+++ b/src/views/Services/Services.jsx
@@ -6,58 +6,80 @@ const services = [
   {
     path: "/services/daily-strolls",
     title: "Daily strolls",
-    description: "Tailored walks for your furry friend.",
+    description: "Personalised walks matched to your companion’s pace and routine.",
     imageSrc: "/images/dogs/lola/lola1.jpeg",
     imageAlt: "Dog enjoying a neighborhood walk",
-  },
-  {
-    path: "/services/group-adventures",
-    title: "Group adventures",
-    description: "Join friendly packs for social fun.",
-    imageSrc: "/images/1a2eb736-6cd3-4d5b-9798-f040dc1d80b9.avif",
-    imageAlt: "Group of dogs playing together outdoors",
+    priceLabel: "From £20",
+    tags: ["Solo Walks", "Routine Friendly", "Photo Updates"],
   },
   {
     path: "/services/solo-journeys",
     title: "Solo journeys",
-    description: "Dedicated care for your pet.",
-    imageSrc: "/images/2269ca18-ac55-435f-bc79-d145bb23389b.avif",
+    description:
+      "One-to-one walks that provide calm, focused attention just for your companion.",
+    imageSrc: "/images/dogs/lakta/lakta1.jpg",
     imageAlt: "Dog sitting attentively on a trail",
+    priceLabel: "From £25",
+    tags: ["1-to-1 Care", "Confidence Building", "Calm Pace"],
   },
   {
-    path: "/services/overnight-stays",
-    title: "Overnight stays",
-    description: "Safe and cozy nights.",
-    imageSrc: "/images/25c0c9d1-2e99-484e-817b-bf1e3505d5e8.avif",
-    imageAlt: "Dog resting comfortably indoors",
+    path: "/services/group-adventures",
+    title: "Group adventures",
+    description:
+      "Fun, confidence-building outings where companions explore and play together.",
+    imageSrc: "/images/dogs/lakta/lakta2.jpg",
+    imageAlt: "Group of dogs playing together outdoors",
+    priceLabel: "From £18",
+    tags: ["Social Play", "Safe Packs", "Adventure Routes"],
   },
   {
     path: "/services/daytime-care",
     title: "Daytime care",
-    description: "Engaging and secure day care.",
-    imageSrc: "/images/a58085e9-4555-461c-9f59-6029e44d0a55.avif",
+    description:
+      "Stimulating, reassuring days perfect for companions who love company.",
+    imageSrc: "/images/dogs/aslan/aslan.jpg",
     imageAlt: "Dog being cared for during daytime playtime",
+    priceLabel: "From £30",
+    tags: ["Playtime", "Rest Breaks", "Structured Day"],
   },
   {
     path: "/services/home-check-ins",
     title: "Home check-ins",
-    description: "Quick visits for your pet's needs.",
-    imageSrc: "/images/bc30b5db-c4fa-466a-a797-7ef1e270262b.avif",
+    description:
+      "Comforting drop-ins that keep your companion relaxed and well looked after.",
+    imageSrc: "/images/dogs/Nola/nola2.jpg",
     imageAlt: "Person greeting a dog inside a home",
+    priceLabel: "From £15",
+    tags: ["Feeding", "Fresh Water", "Home Comfort"],
+  },
+  {
+    path: "/services/overnight-stays",
+    title: "Overnight stays",
+    description: "A homely stay where your companion rests comfortably and feels safe.",
+    imageSrc: "/images/dogs/Johnny/Johnny.jpeg",
+    imageAlt: "Dog resting comfortably indoors",
+    priceLabel: "From £55/night",
+    tags: ["Overnight Care", "Cosy Spaces", "24/7 Presence"],
   },
   {
     path: "/services/training-help",
     title: "Training help",
-    description: "Guidance for training essentials.",
-    imageSrc: "/images/2b4d97a3-883d-4557-abc5-8cf8f3f95400.avif",
+    description:
+      "Supportive guidance to build good habits and boost your companion’s confidence.",
+    imageSrc: "/images/dogs/pancho/pancho2.jpeg",
     imageAlt: "Trainer working with a dog",
+    priceLabel: "From £35",
+    tags: ["Positive Methods", "Behaviour Goals", "Owner Support"],
   },
   {
     path: "/services/custom-solutions",
     title: "Custom solutions",
-    description: "Personalized care plans.",
-    imageSrc: "/images/d801bc7b-4e2e-4836-8ed2-f4f819ecc79a.avif",
+    description:
+      "Tailored care shaped around your companion’s personality and lifestyle.",
+    imageSrc: "/images/dogs/ollie/ollie1.jpeg",
     imageAlt: "Owner cuddling with a relaxed dog",
+    priceLabel: "Custom",
+    tags: ["Flexible Plan", "Built For You", "Mix & Match"],
   },
 ];
 
@@ -69,64 +91,49 @@ const Services = () => {
           <div className="header is-align-center">
             <div className="heading_h1">Our services</div>
             <h2 className="heading_h3">Pick the perfect fit</h2>
-            <p className="subheading max-width_large">
-              Choose from trusted walks, engaging adventures, supportive
-              training, and cozy stays. Every option is delivered with the same
-              friendly, professional care.
-            </p>
           </div>
 
-          <div className="w-layout-grid grid_3-col tablet-1-col gap-small services-grid">
+          <div className="w-layout-grid grid_3-col tablet-1-col gap-small services-grid services-grid--showcase">
             {services.map((service) => (
-              <div
-                key={service.title}
-                className="card height_100percent services-card"
-              >
-                <div className="card-link flex_vertical gap-small height_100percent">
-                  <div className="services-card_image">
-                    <Image
-                      src={service.imageSrc}
-                      alt={service.imageAlt}
-                      fill
-                      sizes="(max-width: 991px) 100vw, 400px"
-                      priority={service.title === "Daily strolls"}
-                      className="image_cover"
-                    />
+              <article key={service.title} className="services-showcase-card">
+                <div className="services-showcase-media">
+                  <Image
+                    src={service.imageSrc}
+                    alt={service.imageAlt}
+                    fill
+                    sizes="(max-width: 991px) 100vw, 400px"
+                    priority={service.title === "Daily strolls"}
+                    className="image_cover"
+                  />
+                  <span className="services-showcase-price">{service.priceLabel}</span>
+                </div>
+
+                <div className="services-showcase-body">
+                  <h3 className="heading_h4 margin-bottom_xsmall">{service.title}</h3>
+                  <p className="paragraph_small text-color_secondary margin-bottom_small">
+                    {service.description}
+                  </p>
+
+                  <div className="services-showcase-tags">
+                    {service.tags.map((tag) => (
+                      <span key={tag} className="services-showcase-tag">
+                        {tag}
+                      </span>
+                    ))}
                   </div>
-                  <div className="card_body text-overlay flex_vertical flex_child-expand">
-                    <div className="heading_h4 eyebrow margin-bottom_none" style={{ marginTop: 5 }}>
-                      {service.title}
-                    </div>
+
+                  <div className="services-showcase-footer">
+                    <Link href={service.path} className="button services-card_button w-button">
+                      <span>View service</span>
+                      <span className="button_icon" aria-hidden="true">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 16" fill="none">
+                          <path d="M2 8H14.5M14.5 8L8.5 2M14.5 8L8.5 14" stroke="currentColor" strokeWidth="2" strokeLinejoin="round"></path>
+                        </svg>
+                      </span>
+                    </Link>
                   </div>
                 </div>
-                <div className="button-group services-card_actions">
-                  <p className="paragraph_small text-color_secondary" style={{ marginTop: 5 }}>
-                      {service.description}
-                    </p>
-                  <Link
-                    href={service.path}
-                    className="button services-card_button w-button"
-                  >
-                    <span>View {service.title.toLowerCase()}</span>
-                    <span className="button_icon" aria-hidden="true">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="100%"
-                        height="100%"
-                        viewBox="0 0 16 16"
-                        fill="none"
-                      >
-                        <path
-                          d="M2 8H14.5M14.5 8L8.5 2M14.5 8L8.5 14"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinejoin="round"
-                        ></path>
-                      </svg>
-                    </span>
-                  </Link>
-                </div>
-              </div>
+              </article>
             ))}
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Update the Services page cards to match the provided reference layout while keeping the existing brand styling and using the same images shown in the Home slider.
- Surface more useful information on each card (price badge, short feature tags) so cards are more informative and scannable.

### Description
- Replaced the old card markup with a new `services-showcase-card` layout in `src/views/Services/Services.jsx`, including a top image panel, floating price badge, tag chips, description block, and CTA footer.
- Switched each service entry to use the same dog photos used by the Home slider and added `priceLabel` and `tags` fields to the local `services` array.
- Added CSS rules for the showcase layout to `src/assets/css/jeroen-paws.css`, including `.services-showcase-card`, `.services-showcase-media`, `.services-showcase-price`, `.services-showcase-tags`, and responsive tweaks.
- Updated the services grid to use the new `services-grid--showcase` modifier and removed the previous card-specific markup.

### Testing
- No automated tests were executed for this change.
- Changes were validated via local code review and basic repository checks and the updated pages/styles render with the new card layout in development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6539fb030832ca7dba80d1069bf9b)